### PR TITLE
convert mongo connection details into a uri.

### DIFF
--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -13,12 +13,7 @@ spring:
     password: ${RABBITMQ_PASSWORD:guest}
   data:
     mongodb:
-      host: ${MONGODB_HOST:localhost}
-      port: ${MONGODB_PORT:27017}
-      database: ${MONGODB_DATABASE:revalidation}
-      username: ${MONGODB_USERNAME:root}
-      password: ${MONGODB_PASSWORD:password}
-      authentication-database: ${AUTH_DB:admin}
+      uri: mongodb://${MONGODB_USERNAME:root}:${MONGODB_PASSWORD:password}@${MONGODB_HOST:localhost}:${MONGODB_PORT:27017}/${MONGODB_DATABASE:revalidation}
 
 server:
   servlet:


### PR DESCRIPTION
When we tried doing it this way in trainee details, the spring connector 
to mongo couldnt connect to documentdb, it required it to be in uri 
format then it worked.