### PR TITLE
fix: added gmc submission date to trainee recommendation dto

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/dto/TraineeRecommendationDto.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/dto/TraineeRecommendationDto.java
@@ -25,6 +25,7 @@ public class TraineeRecommendationDto {
     private LocalDate cctDate;
     private String underNotice;
     private String designatedBody;
+    private LocalDate gmcSubmissionDate;
     private List<TraineeRecommendationRecordDto> revalidations;
     private List<DeferralReasonDto> deferralReasons;
 

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationService.java
@@ -67,6 +67,7 @@ public class RecommendationService {
           .gmcNumber(doctorsForDB.getGmcReferenceNumber())
           .underNotice(doctorsForDB.getUnderNotice().value())
           .designatedBody(doctorsForDB.getDesignatedBodyCode())
+          .gmcSubmissionDate(doctorsForDB.getSubmissionDate())
           .revalidations(getCurrentAndLegacyRecommendation(doctorsForDB))
           .deferralReasons(deferralReasonService.getAllDeferralReasons()).build();
     }

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceTest.java
@@ -221,6 +221,7 @@ public class RecommendationServiceTest {
     assertThat(recommendation.getFullName(), is(getFullName(firstName, lastName)));
     assertThat(recommendation.getUnderNotice(), is(underNotice.value()));
     assertThat(recommendation.getDesignatedBody(), is(designatedBodyCode));
+    assertThat(recommendation.getGmcSubmissionDate(), is(submissionDate));
 
     assertThat(recommendation.getRevalidations(), hasSize(3));
     var revalidationDTO = recommendation.getRevalidations().get(0);
@@ -293,6 +294,7 @@ public class RecommendationServiceTest {
     assertThat(recommendation.getFullName(), is(getFullName(firstName, lastName)));
     assertThat(recommendation.getUnderNotice(), is(underNotice.value()));
     assertThat(recommendation.getDesignatedBody(), is(designatedBodyCode));
+    assertThat(recommendation.getGmcSubmissionDate(), is(submissionDate));
     assertThat(recommendation.getDeferralReasons(), hasSize(2));
 
     assertThat(recommendation.getRevalidations(), hasSize(2));
@@ -352,6 +354,7 @@ public class RecommendationServiceTest {
     assertThat(recommendation.getFullName(), is(getFullName(firstName, lastName)));
     assertThat(recommendation.getUnderNotice(), is(underNotice.value()));
     assertThat(recommendation.getDesignatedBody(), is(designatedBodyCode));
+    assertThat(recommendation.getGmcSubmissionDate(), is(submissionDate));
 
     assertThat(recommendation.getRevalidations(), hasSize(2));
     var revalidationDTO = recommendation.getRevalidations().get(0);


### PR DESCRIPTION
TISNEW-5610

FE needs the gmcSubmissionDate to calculate the deferral logic when creating the recommendation.