### PR TITLE
feat: publish messages to sqs queue (Please don't merge)

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -97,6 +97,16 @@
             <artifactId>sentry-logback</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-aws</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-aws-messaging</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/config/AwsSqsConfig.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/config/AwsSqsConfig.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.aws.messaging.core.QueueMessagingTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+
+@Configuration
+public class AwsSqsConfig {
+
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  @Value("${cloud.aws.credentials.access-key}")
+  private String awsAccessKey;
+
+  @Value("${cloud.aws.credentials.secret-key}")
+  private String awsSecretKey;
+
+  @Bean
+  public QueueMessagingTemplate queueMessagingTemplate() {
+    return new QueueMessagingTemplate(amazonSQSAsync());
+  }
+
+  @Primary
+  @Bean
+  public AmazonSQSAsync amazonSQSAsync() {
+    return AmazonSQSAsyncClientBuilder.standard().withRegion(Regions.EU_WEST_2).withClientConfiguration()
+        .withCredentials(
+            new AWSStaticCredentialsProvider(new BasicAWSCredentials(awsAccessKey, awsSecretKey)))
+        .build();
+  }
+
+  @Bean
+  public MappingJackson2MessageConverter mappingJackson2MessageConverter(
+      ObjectMapper objectMapper) {
+    MappingJackson2MessageConverter jackson2MessageConverter = new MappingJackson2MessageConverter();
+    DateFormat df = new SimpleDateFormat("dd/MM/yyyy");
+    objectMapper.setDateFormat(df);
+    jackson2MessageConverter.setObjectMapper(objectMapper);
+    return jackson2MessageConverter;
+  }
+}

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/controller/GmcDoctorSyncController.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/controller/GmcDoctorSyncController.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.controller;
+
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.aws.messaging.core.QueueMessagingTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.nhs.hee.tis.revalidation.entity.DoctorsForDB;
+import uk.nhs.hee.tis.revalidation.repository.DoctorsForDBRepository;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/sqs")
+public class GmcDoctorSyncController {
+
+  @Value("${cloud.aws.end-point.uri}")
+  private String sqsEndPoint;
+
+  @Autowired
+  private QueueMessagingTemplate queueMessagingTemplate;
+
+  @Autowired
+  private DoctorsForDBRepository doctorsForDBRepository;
+
+  @GetMapping("/send-doctor")
+  public ResponseEntity sendMessage() {
+    List<DoctorsForDB> allGmcDoctors = doctorsForDBRepository.findAll();
+    log.info("Total doctors fetched from the db: {}", allGmcDoctors.stream().count());
+    sendToSqsQueue(allGmcDoctors);
+
+    return ResponseEntity.ok().body("success");
+  }
+
+  private void sendToSqsQueue(final List<DoctorsForDB> gmcDoctors) {
+    gmcDoctors.stream()
+        .forEach(doctor -> queueMessagingTemplate.convertAndSend(sqsEndPoint, doctor));
+  }
+
+}

--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -73,3 +73,16 @@ app:
 sentry:
   dsn: ${SENTRY_DSN:}
   environment: ${SENTRY_ENVIRONMENT:}
+
+cloud:
+  aws:
+    region:
+      static: ${AWS_STATIC_REGION:eu-west-2}
+      auto: false
+    credentials:
+      access-key: ${ACCESS_KEY:}
+      secret-key: ${SECRET_KEY:}
+    stack:
+      auto: false
+    end-point:
+      uri: ${QUEUE_NAME:}

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/controller/GmcDoctorSyncControllerTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/controller/GmcDoctorSyncControllerTest.java
@@ -1,0 +1,115 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.controller;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.aws.messaging.core.QueueMessagingTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.nhs.hee.tis.revalidation.entity.DoctorsForDB;
+import uk.nhs.hee.tis.revalidation.entity.RecommendationStatus;
+import uk.nhs.hee.tis.revalidation.entity.UnderNotice;
+import uk.nhs.hee.tis.revalidation.repository.DoctorsForDBRepository;
+
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest(GmcDoctorSyncController.class)
+public class GmcDoctorSyncControllerTest {
+
+  @MockBean
+  private DoctorsForDBRepository doctorsForDBRepository;
+
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private QueueMessagingTemplate queueMessagingTemplate;
+
+  private final List<DoctorsForDB> allDoctors = new ArrayList<>();
+
+  /**
+   * setup data for testing.
+   */
+  @BeforeEach
+  public void setup() {
+    DoctorsForDB doctorsForDB1 = DoctorsForDB.builder()
+        .gmcReferenceNumber("101")
+        .doctorFirstName("AAA")
+        .doctorLastName("BBB")
+        .submissionDate(LocalDate.now())
+        .dateAdded(LocalDate.now())
+        .underNotice(UnderNotice.NO)
+        .sanction("sanc")
+        .doctorStatus(RecommendationStatus.NOT_STARTED)
+        .lastUpdatedDate(LocalDate.now())
+        .designatedBodyCode("PQR")
+        .admin("Reval Admin").build();
+
+    allDoctors.add(doctorsForDB1);
+
+    DoctorsForDB doctorsForDB2 = DoctorsForDB.builder()
+        .gmcReferenceNumber("201")
+        .doctorFirstName("CCC")
+        .doctorLastName("DDD")
+        .submissionDate(LocalDate.now())
+        .dateAdded(LocalDate.now().minusDays(3))
+        .underNotice(UnderNotice.NO)
+        .sanction("sanc")
+        .doctorStatus(RecommendationStatus.NOT_STARTED)
+        .lastUpdatedDate(LocalDate.now())
+        .designatedBodyCode("XYZ")
+        .admin("Reval Admin").build();
+
+    allDoctors.add(doctorsForDB2);
+
+  }
+
+  @Test
+  public void shouldSendMessageToSqs() throws Exception {
+    when(doctorsForDBRepository.findAll()).thenReturn(allDoctors);
+
+    this.mockMvc.perform(get("/api/v1/sqs/send-doctor"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("success"));
+
+    assertThat(allDoctors.size(), is(2));
+    assertThat(allDoctors.get(0).getGmcReferenceNumber(), is("101"));
+    assertThat(allDoctors.get(1).getGmcReferenceNumber(), is("201"));
+
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
             ${project.build.directory}/checkstyle-result.xml
         </sonar.java.checkstyle.reportPaths>
         <commons-collections4.version>4.4</commons-collections4.version>
+        <spring-cloud.version>2.2.6.RELEASE</spring-cloud.version>
+        <spring-cloud-aws-messaging.version>2.2.6.RELEASE</spring-cloud-aws-messaging.version>
     </properties>
 
     <dependencyManagement>
@@ -115,6 +117,18 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-collections4</artifactId>
                 <version>${commons-collections4.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-starter-aws</artifactId>
+                <version>${spring-cloud.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-starter-aws-messaging</artifactId>
+                <version>${spring-cloud-aws-messaging.version}</version>
             </dependency>
 
             <!-- testing -->


### PR DESCRIPTION
TIS21-1264
I have used here **spring-cloud-starter-aws-messaging** library. Did some research on this. In compare to AWS SQS SDK library

-- lots of boiler plate code is not needed here
--message dto format can be handled using a bean
--reading message is easier
--don't have to delete the message from the queue manually after subscribing
--built in polling mechanism

Downside?
Access key and secret access key is explicit (But there must be a solution for this, I am looking into it)