### PR TITLE
Revert "chore(deps): bump checkstyle from 8.41 to 8.41.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.41.1</version>
+                        <version>8.41</version>
                     </dependency>
                 </dependencies>
                 <executions>


### PR DESCRIPTION
Reverts Health-Education-England/tis-revalidation-recommendation#182

The dockerisation is failing for some reason