### PR TITLE
chore: Use terraform managed queue url parameter

### DIFF
--- a/.aws/task-definition-prod.json
+++ b/.aws/task-definition-prod.json
@@ -33,59 +33,59 @@
       "secrets": [
         {
           "name": "MONGODB_HOST",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-mongo-prod-host"
+          "valueFrom": "tis-revalidation-mongo-prod-host"
         },
         {
           "name": "MONGODB_PORT",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-mongo-prod-port"
+          "valueFrom": "tis-revalidation-mongo-prod-port"
         },
         {
           "name": "MONGODB_USERNAME",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-mongo-prod-user"
+          "valueFrom": "tis-revalidation-mongo-prod-user"
         },
         {
           "name": "MONGODB_PASSWORD",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-mongo-prod-password"
+          "valueFrom": "tis-revalidation-mongo-prod-password"
         },
         {
           "name": "RABBITMQ_HOST",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-prod-private-lb-url"
+          "valueFrom": "tis-revalidation-prod-private-lb-url"
         },
         {
           "name": "RABBITMQ_PASSWORD",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-rabbit-prod-password"
+          "valueFrom": "tis-revalidation-rabbit-prod-password"
         },
         {
           "name": "RABBITMQ_PORT",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-rabbit-prod-port"
+          "valueFrom": "tis-revalidation-rabbit-prod-port"
         },
         {
           "name": "RABBITMQ_USERNAME",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-rabbit-prod-username"
+          "valueFrom": "tis-revalidation-rabbit-prod-username"
         },
         {
           "name": "GMC_CONNECT_URL",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-gmc-prod-connect-url"
+          "valueFrom": "tis-revalidation-gmc-prod-connect-url"
         },
         {
           "name": "GMC_USER_NAME",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-gmc-prod-username"
+          "valueFrom": "tis-revalidation-gmc-prod-username"
         },
         {
           "name": "GMC_PASSWORD",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-gmc-prod-password"
+          "valueFrom": "tis-revalidation-gmc-prod-password"
         },
         {
           "name": "DESIGNATED_BODY_CODE",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/reval-gmc-designated-bodies-codes"
+          "valueFrom": "reval-gmc-designated-bodies-codes"
         },
         {
           "name": "SENTRY_DSN",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-recommendation-sentry-dsn"
+          "valueFrom": "tis-revalidation-recommendation-sentry-dsn"
         },
         {
           "name": "QUEUE_NAME",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-recommendation-sqs-queue-prod"
+          "valueFrom": "/tis/revalidation/recommendation/prod/queue-url"
         }
       ]
     }

--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -2,7 +2,7 @@
   "containerDefinitions": [
     {
       "name": "tis-revalidation-recommendation",
-      "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/tis-revalidation-recommendation:1",
+      "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/tis-revalidation-recommendation:latest",
       "portMappings": [
         {
           "containerPort": 8080
@@ -33,63 +33,63 @@
       "secrets": [
         {
           "name": "MONGODB_HOST",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/reval-mongo-host"
+          "valueFrom": "reval-mongo-host"
         },
         {
           "name": "MONGODB_PORT",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/reval-mongo-port"
+          "valueFrom": "reval-mongo-port"
         },
         {
           "name": "MONGODB_USERNAME",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/reval-mongo-user"
+          "valueFrom": "reval-mongo-user"
         },
         {
           "name": "MONGODB_PASSWORD",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/reval-mongo-password"
+          "valueFrom": "reval-mongo-password"
         },
         {
           "name": "RABBITMQ_HOST",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/reval-rabbit-host"
+          "valueFrom": "reval-rabbit-host"
         },
         {
           "name": "RABBITMQ_PASSWORD",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/reval-rabbit-password"
+          "valueFrom": "reval-rabbit-password"
         },
         {
           "name": "RABBITMQ_PORT",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/reval-rabbit-port"
+          "valueFrom": "reval-rabbit-port"
         },
         {
           "name": "RABBITMQ_USERNAME",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/reval-rabbit-username"
+          "valueFrom": "reval-rabbit-username"
         },
         {
           "name": "TCS_URL",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tcs-url"
+          "valueFrom": "tcs-url"
         },
         {
           "name": "GMC_CONNECT_URL",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/reval-gmc-connect-url"
+          "valueFrom": "reval-gmc-connect-url"
         },
         {
           "name": "GMC_USER_NAME",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/reval-gmc-username"
+          "valueFrom": "reval-gmc-username"
         },
         {
           "name": "GMC_PASSWORD",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/reval-gmc-password"
+          "valueFrom": "reval-gmc-password"
         },
         {
           "name": "DESIGNATED_BODY_CODE",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/reval-gmc-designated-bodies-codes"
+          "valueFrom": "reval-gmc-designated-bodies-codes"
         },
         {
           "name": "SENTRY_DSN",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-recommendation-sentry-dsn"
+          "valueFrom": "tis-revalidation-recommendation-sentry-dsn"
         },
         {
           "name": "QUEUE_NAME",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-recommendation-sqs-queue-preprod"
+          "valueFrom": "/tis/revalidation/recommendation/preprod/queue-url"
         }
       ]
     }


### PR DESCRIPTION
The current queue url parameters were added manually and are not managed
by Terraform.
Switch `QUEUE_NAME` to the Terraform managed parameter.

TIS21-1517