### PR TITLE
chore: Add auto-caching using setup-java action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,9 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v2.3.0
         with:
+          cache: maven
           distribution: adopt
           java-version: 11
 
@@ -59,9 +60,10 @@ jobs:
           name: app-jar
           path: build/reports
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v2.3.0
         with:
+          cache: maven
           distribution: adopt
           java-version: 11
 


### PR DESCRIPTION
The `setup-java` action now supports automatic caching of maven and
gradle dependencies, update the workflow to use that caching.

TIS21-2078