### PR TITLE
fix: update tis status when gmc outcome update

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceImpl.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceImpl.java
@@ -93,7 +93,8 @@ public class RecommendationServiceImpl implements RecommendationService {
               .designatedBody(doctorsForDB.getDesignatedBodyCode())
               .gmcSubmissionDate(doctorsForDB.getSubmissionDate())
               .revalidations(getCurrentAndLegacyRecommendation(doctorsForDB))
-              .deferralReasons(deferralReasonService.getAllCurrentDeferralReasons()).build();
+              .deferralReasons(deferralReasonService.getAllCurrentDeferralReasons())
+              .build();
     }
 
     return null;
@@ -272,6 +273,9 @@ public class RecommendationServiceImpl implements RecommendationService {
     final var gmcNumber = doctorsForDB.getGmcReferenceNumber();
     checkRecommendationStatus(gmcNumber, doctorsForDB.getDesignatedBodyCode());
     log.info("Fetching snapshot record for GmcId: {}", gmcNumber);
+
+    doctorsForDB.setDoctorStatus(getRecommendationStatusForTrainee(gmcNumber));
+    doctorsForDBRepository.save(doctorsForDB);
 
     final var recommendations = recommendationRepository.findByGmcNumber(gmcNumber);
     final var currentRecommendations = recommendations.stream().map(rec ->

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceImpl.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceImpl.java
@@ -272,11 +272,14 @@ public class RecommendationServiceImpl implements RecommendationService {
       final DoctorsForDB doctorsForDB) {
     final var gmcNumber = doctorsForDB.getGmcReferenceNumber();
     checkRecommendationStatus(gmcNumber, doctorsForDB.getDesignatedBodyCode());
+
+    final var newRecommendationStatus  = getRecommendationStatusForTrainee(gmcNumber);
+    if(!newRecommendationStatus.equals(doctorsForDB.getDoctorStatus())){
+      doctorsForDB.setDoctorStatus(newRecommendationStatus );
+      doctorsForDBRepository.save(doctorsForDB);
+    }
+
     log.info("Fetching snapshot record for GmcId: {}", gmcNumber);
-
-    doctorsForDB.setDoctorStatus(getRecommendationStatusForTrainee(gmcNumber));
-    doctorsForDBRepository.save(doctorsForDB);
-
     final var recommendations = recommendationRepository.findByGmcNumber(gmcNumber);
     final var currentRecommendations = recommendations.stream().map(rec ->
       buildTraineeRecommendationRecordDto(gmcNumber, doctorsForDB.getSubmissionDate(), rec)

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceTest.java
@@ -306,7 +306,7 @@ class RecommendationServiceTest {
   }
 
   @Test
-  void shouldUpdateSnapshotIfRecommendationStatusBecomeApprove() throws ParseException {
+  void shouldUpdateSnapshotAndDoctorIfRecommendationStatusBecomeApprove() {
     final var gmcId = faker.number().digits(7);
     final var doctorsForDB = buildDoctorForDB(gmcId);
     when(doctorsForDBRepository.findById(gmcId)).thenReturn(of(doctorsForDB));
@@ -317,6 +317,7 @@ class RecommendationServiceTest {
     when(gmcClientService.checkRecommendationStatus(gmcNumber1,
         gmcRecommendationId2, recommendationId, designatedBodyCode)).thenReturn(APPROVED);
     when(deferralReasonService.getAllCurrentDeferralReasons()).thenReturn(deferralReasons);
+    when(recommendationRepository.findFirstByGmcNumberOrderByActualSubmissionDateDesc(gmcId))
 
     when(snapshot1.getAdmin()).thenReturn(admin1);
     when(snapshot1.getGmcNumber()).thenReturn(gmcId);
@@ -366,6 +367,7 @@ class RecommendationServiceTest {
 
     verify(recommendationRepository).save(recommendation1);
     verify(snapshotService).saveRecommendationToSnapshot(recommendation1);
+    verify(doctorsForDBRepository).save(doctorsForDB);
   }
 
   @Test


### PR DESCRIPTION
Objective is to ensure tis status (i.e. DoctorsForDB.doctorStatus) is updated when recommendation details page is loaded

I've put the check in what I think is the best place, given that this part of the service is fairly "spaghetti-ish" with lots of side-effects - open to suggestions on better placement that doesn't require major refactor