### PR TITLE
chore: use renamed status check EnvVar in task def

### DIFF
--- a/.aws/task-definition-prod.json
+++ b/.aws/task-definition-prod.json
@@ -90,6 +90,10 @@
         {
           "name": "SQS_SYNC_GMC_QUEUE",
           "valueFrom": "/tis/revalidation/sync-gmc/prod/queue-url"
+        },
+        {
+          "name": "REC_STATUS_CHECK_CRON",
+          "valueFrom": "/tis/revalidation/prod/recommendation/cron/recommendationstatuscheck"
         }
       ]
     }

--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -94,6 +94,10 @@
         {
           "name": "SQS_SYNC_GMC_QUEUE",
           "valueFrom": "/tis/revalidation/sync-gmc/preprod/queue-url"
+        },
+        {
+          "name": "REC_STATUS_CHECK_CRON",
+          "valueFrom": "/tis/revalidation/preprod/recommendation/cron/recommendationstatuscheck"
         }
       ]
     }

--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -74,7 +74,7 @@ app:
     gmcUsername: ${GMC_USER_NAME:guest}
     gmcPassword: ${GMC_PASSWORD:guest}
     designatedBodies: ${DESIGNATED_BODY_CODE:1-AIIDHJ,1-AIIDMQ,1-AIIDNQ,1-AIIDMY,1-AIIDQQ,1-AIIDWT,1-AIIDR8,1-AIIDSA,1-AIIDH1,1-AIIDWA,1-AIIDVS,1-AIIDWI,1-AIIDSI}
-    recommendationstatuscheck.cronExpression: ${CRON_EXPRESSION:0 0 * * * *}
+    recommendationstatuscheck.cronExpression: ${REC_STATUS_CHECK_CRON:0 0 * * * *}
 
 sentry:
   dsn: ${SENTRY_DSN:}


### PR DESCRIPTION
We already have a genuine desire to use a different frequency for the
 Recommendation Status Check scheduled task.

TIS21-2355: Refresh the Recommendations list frequently