### PR TITLE
fix: hide potentially disconnected doctors and start doctor sync

### DIFF
--- a/.aws/task-definition-prod.json
+++ b/.aws/task-definition-prod.json
@@ -94,6 +94,10 @@
         {
           "name": "REC_STATUS_CHECK_CRON",
           "valueFrom": "/tis/revalidation/prod/recommendation/cron/recommendationstatuscheck"
+        },
+        {
+          "name": "REC_NIGHTLY_SYNC_CRON",
+          "valueFrom": "/tis/revalidation/prod/recommendation/cron/nightlysync"
         }
       ]
     }

--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -98,6 +98,10 @@
         {
           "name": "REC_STATUS_CHECK_CRON",
           "valueFrom": "/tis/revalidation/preprod/recommendation/cron/recommendationstatuscheck"
+        },
+        {
+          "name": "REC_NIGHTLY_SYNC_CRON",
+          "valueFrom": "/tis/revalidation/preprod/recommendation/cron/nightlysync"
         }
       ]
     }

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/publisher/GmcDoctorsForDbSyncStartPublisher.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/publisher/GmcDoctorsForDbSyncStartPublisher.java
@@ -7,9 +7,9 @@ public class GmcDoctorsForDbSyncStartPublisher {
 
   private String startMessage = "${app.gmc.nightlySyncStartMessage}";
 
-  private MessagePublisher messagePublisher;
+  private MessagePublisher<String> messagePublisher;
 
-  public GmcDoctorsForDbSyncStartPublisher(MessagePublisher messagePublisher) {
+  public GmcDoctorsForDbSyncStartPublisher(MessagePublisher<String> messagePublisher) {
     this.messagePublisher = messagePublisher;
   }
 

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/publisher/GmcDoctorsForDbSyncStartPublisher.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/publisher/GmcDoctorsForDbSyncStartPublisher.java
@@ -1,0 +1,23 @@
+package uk.nhs.hee.tis.revalidation.messages.publisher;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class GmcDoctorsForDbSyncStartPublisher {
+
+  private String startMessage = "${app.gmc.nightlySyncStartMessage}";
+
+  private MessagePublisher messagePublisher;
+
+  public GmcDoctorsForDbSyncStartPublisher(MessagePublisher messagePublisher) {
+    this.messagePublisher = messagePublisher;
+  }
+
+  /**
+   * Publishes message to broker
+   */
+  public void publishNightlySyncStartMessage() {
+    messagePublisher.publishToBroker(startMessage);
+  }
+
+}

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/publisher/MessagePublisher.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/publisher/MessagePublisher.java
@@ -19,31 +19,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.revalidation.controller;
+package uk.nhs.hee.tis.revalidation.messages.publisher;
 
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import uk.nhs.hee.tis.revalidation.service.GmcDoctorConnectionSyncService;
+public interface MessagePublisher<T> {
 
-@Slf4j
-@RestController
-@RequestMapping("/api/v1/sqs")
-public class GmcDoctorSyncController {
-
-  private final GmcDoctorConnectionSyncService gmcDoctorConnectionSyncService;
-
-  public GmcDoctorSyncController(final GmcDoctorConnectionSyncService gmcDoctorConnectionSyncService) {
-    this.gmcDoctorConnectionSyncService = gmcDoctorConnectionSyncService;
-  }
-
-  @GetMapping("/send-doctor")
-  public ResponseEntity<Void> startGmcSync() {
-    //this endpoint is needed to start gmc sync manually
-    gmcDoctorConnectionSyncService.receiveMessage("gmcSyncStart");
-    return ResponseEntity.ok().build();
-  }
-
+  void publishToBroker(T message);
 }
+

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/publisher/RabbitMqMessagePublisher.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/publisher/RabbitMqMessagePublisher.java
@@ -32,7 +32,7 @@ public class RabbitMqMessagePublisher<T> implements MessagePublisher<T> {
   @Value("${app.rabbit.reval.exchange}")
   private String exchange;
 
-  @Value("${reval.routingKey.gmcsync.requested.gmcclient}")
+  @Value("${app.rabbit.reval.routingKey.gmcsync.requested.gmcclient}")
   private String routingKey;
 
   @Autowired

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/publisher/RabbitMqMessagePublisher.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/publisher/RabbitMqMessagePublisher.java
@@ -32,7 +32,7 @@ public class RabbitMqMessagePublisher<T> implements MessagePublisher<T> {
   @Value("${app.rabbit.reval.exchange}")
   private String exchange;
 
-  @Value("${app.rabbit.reval.routingKey.gmcsync.syncStarted}")
+  @Value("${app.rabbit.reval.queue.gmcsync.requested.gmcclient}")
   private String routingKey;
 
   @Autowired

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/publisher/RabbitMqMessagePublisher.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/publisher/RabbitMqMessagePublisher.java
@@ -32,7 +32,7 @@ public class RabbitMqMessagePublisher<T> implements MessagePublisher<T> {
   @Value("${app.rabbit.reval.exchange}")
   private String exchange;
 
-  @Value("${app.rabbit.reval.queue.gmcsync.requested.gmcclient}")
+  @Value("${reval.routingKey.gmcsync.requested.gmcclient}")
   private String routingKey;
 
   @Autowired

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
@@ -59,6 +59,8 @@ public class DoctorsForDBService {
   @Value("${app.reval.pagination.pageSize}")
   private int pageSize;
 
+  private String hiddenPrefix = "last-";
+
   private DoctorsForDBRepository doctorsRepository;
 
   private RecommendationService recommendationService;
@@ -149,7 +151,9 @@ public class DoctorsForDBService {
   public void hideAllDoctors() {
     List<DoctorsForDB> doctors = doctorsRepository.findAll();
     doctors.stream().forEach(doctor -> {
-      doctor.setDesignatedBodyCode("last-"+doctor.getDesignatedBodyCode());
+      doctor.setDesignatedBodyCode(
+          getHiddenDesignatedBodyCode(doctor.getDesignatedBodyCode())
+      );
       doctorsRepository.save(doctor);
     });
   }
@@ -202,6 +206,14 @@ public class DoctorsForDBService {
 
   private String getConnectionStatus(final String designatedBody) {
     return (designatedBody == null || designatedBody.equals("")) ? "No" : "Yes";
+  }
+
+  private String getHiddenDesignatedBodyCode(String dbCode) {
+    if(!dbCode.startsWith(hiddenPrefix)){
+      return hiddenPrefix + dbCode;
+    } else {
+      return dbCode;
+    }
   }
 
 

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
@@ -146,6 +146,14 @@ public class DoctorsForDBService {
         .totalResults(traineeInfoDtos.size()).traineeInfo(traineeInfoDtos).build();
   }
 
+  public void hideAllDoctors() {
+    List<DoctorsForDB> doctors = doctorsRepository.findAll();
+    doctors.stream().forEach(doctor -> {
+      doctor.setDesignatedBodyCode("last-"+doctor.getDesignatedBodyCode());
+      doctorsRepository.save(doctor);
+    });
+  }
+
   private TraineeInfoDto convert(final DoctorsForDB doctorsForDB) {
     final var traineeInfoDTOBuilder = TraineeInfoDto.builder()
         .gmcReferenceNumber(doctorsForDB.getGmcReferenceNumber())

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorConnectionSyncService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorConnectionSyncService.java
@@ -32,7 +32,7 @@ import uk.nhs.hee.tis.revalidation.repository.DoctorsForDBRepository;
 
 @Slf4j
 @Service
-public class GmcDoctorSyncService {
+public class GmcDoctorConnectionSyncService {
 
   private final QueueMessagingTemplate queueMessagingTemplate;
   private final DoctorsForDBRepository doctorsForDBRepository;
@@ -41,7 +41,7 @@ public class GmcDoctorSyncService {
   @Value("${cloud.aws.end-point.uri}")
   private String sqsEndPoint;
 
-  public GmcDoctorSyncService(QueueMessagingTemplate queueMessagingTemplate,
+  public GmcDoctorConnectionSyncService(QueueMessagingTemplate queueMessagingTemplate,
       DoctorsForDBRepository doctorsForDBRepository) {
     this.queueMessagingTemplate = queueMessagingTemplate;
     this.doctorsForDBRepository = doctorsForDBRepository;

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorNightlySyncService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorNightlySyncService.java
@@ -1,9 +1,9 @@
 package uk.nhs.hee.tis.revalidation.service;
 
-import org.springframework.stereotype.Component;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.revalidation.messages.publisher.GmcDoctorsForDbSyncStartPublisher;
-import uk.nhs.hee.tis.revalidation.service.DoctorsForDBService;
 
 @Service
 public class GmcDoctorNightlySyncService {
@@ -20,6 +20,8 @@ public class GmcDoctorNightlySyncService {
     this.doctorsForDBService = doctorsForDBService;
   }
 
+  @Scheduled(cron="${app.gmc.nightlySyncStart.cronExpression}")
+  @SchedulerLock(name = "GmcNightlySyncJob")
   public void startNightlyGmcDoctorSync() {
     this.doctorsForDBService.hideAllDoctors();
     this.gmcDoctorsForDbSyncStartPublisher.publishNightlySyncStartMessage();

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorNightlySyncService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorNightlySyncService.java
@@ -4,6 +4,7 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.revalidation.messages.publisher.GmcDoctorsForDbSyncStartPublisher;
+import uk.nhs.hee.tis.revalidation.repository.DoctorsForDBRepository;
 
 @Service
 public class GmcDoctorNightlySyncService {

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorNightlySyncService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorNightlySyncService.java
@@ -4,7 +4,6 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.revalidation.messages.publisher.GmcDoctorsForDbSyncStartPublisher;
-import uk.nhs.hee.tis.revalidation.repository.DoctorsForDBRepository;
 
 @Service
 public class GmcDoctorNightlySyncService {

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorNightlySyncService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorNightlySyncService.java
@@ -1,0 +1,28 @@
+package uk.nhs.hee.tis.revalidation.service;
+
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.revalidation.messages.publisher.GmcDoctorsForDbSyncStartPublisher;
+import uk.nhs.hee.tis.revalidation.service.DoctorsForDBService;
+
+@Service
+public class GmcDoctorNightlySyncService {
+
+  private GmcDoctorsForDbSyncStartPublisher gmcDoctorsForDbSyncStartPublisher;
+
+  private DoctorsForDBService doctorsForDBService;
+
+  public GmcDoctorNightlySyncService(
+      DoctorsForDBService doctorsForDBService,
+      GmcDoctorsForDbSyncStartPublisher gmcDoctorsForDbSyncStartPublisher
+  ) {
+    this.gmcDoctorsForDbSyncStartPublisher = gmcDoctorsForDbSyncStartPublisher;
+    this.doctorsForDBService = doctorsForDBService;
+  }
+
+  public void startNightlyGmcDoctorSync() {
+    this.doctorsForDBService.hideAllDoctors();
+    this.gmcDoctorsForDbSyncStartPublisher.publishNightlySyncStartMessage();
+  }
+
+}

--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -69,6 +69,7 @@ app:
     reval.queue.recommendationStatusCheck.updated: ${REVAL_RABBIT_RECOMMENDATION_STATUS_CHECK_UPDATED_QUEUE:reval.queue.recommendationstatuscheck.updated.recommendation}
     reval.routingKey.recommendationstatuscheck.requested: ${REVAL_RABBIT_RECOMMENDATION_STATUS_CHECK_REQUESTED_ROUTING_KEY:reval.recommendationstatuscheck.requested}
     reval.queue.gmcsync.requested.gmcclient: ${REVAL_RABBIT_GMCSYNC_REQUESTED_GMCCLIENT_QUEUE:reval.queue.gmcsync.requested.gmcclient}
+    reval.routingKey.gmcsync.requested.gmcclient: ${REVAL_RABBIT_GMCSYNC_REQUESTED_GMCCLIENT_ROUTING_KEY:reval.gmcsync.requested}
 
   gmc:
     url: ${GMC_CONNECT_URL:http://localhost:8090/GMCConnectMock2020/GMCWebServices}

--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -78,8 +78,8 @@ app:
     gmcPassword: ${GMC_PASSWORD:guest}
     designatedBodies: ${DESIGNATED_BODY_CODE:1-AIIDHJ,1-AIIDMQ,1-AIIDNQ,1-AIIDMY,1-AIIDQQ,1-AIIDWT,1-AIIDR8,1-AIIDSA,1-AIIDH1,1-AIIDWA,1-AIIDVS,1-AIIDWI,1-AIIDSI}
     recommendationstatuscheck.cronExpression: ${REC_STATUS_CHECK_CRON:0 0 * * * *}
-    nightlySyncStart.cronExpression: ${REC_STATUS_CHECK_CRON:0 0 * * * *}
-    nightlySyncStartMessage: ${NIGHTLY_SYNC_START_MESSAGE:start}
+    nightlySyncStart.cronExpression: ${REC_NIGHTLY_SYNC_CRON:0 0 * * * *}
+    nightlySyncStartMessage: ${REC_NIGHTLY_SYNC_START_MESSAGE:start}
 
   scheduling:
     lock:

--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -68,6 +68,7 @@ app:
     reval.routingKey.recommendation.syncstart: ${REVAL_RABBIT_RECOMMENDATION_SYNCSTART_ROUTING_KEY:reval.recommendation.syncstart}
     reval.queue.recommendationStatusCheck.updated: ${REVAL_RABBIT_RECOMMENDATION_STATUS_CHECK_UPDATED_QUEUE:reval.queue.recommendationstatuscheck.updated.recommendation}
     reval.routingKey.recommendationstatuscheck.requested: ${REVAL_RABBIT_RECOMMENDATION_STATUS_CHECK_REQUESTED_ROUTING_KEY:reval.recommendationstatuscheck.requested}
+    reval.queue.gmcsync.requested.gmcclient: ${REVAL_RABBIT_GMCSYNC_REQUESTED_GMCCLIENT_QUEUE:reval.queue.gmcsync.requested.gmcclient}
 
   gmc:
     url: ${GMC_CONNECT_URL:http://localhost:8090/GMCConnectMock2020/GMCWebServices}
@@ -76,6 +77,7 @@ app:
     gmcPassword: ${GMC_PASSWORD:guest}
     designatedBodies: ${DESIGNATED_BODY_CODE:1-AIIDHJ,1-AIIDMQ,1-AIIDNQ,1-AIIDMY,1-AIIDQQ,1-AIIDWT,1-AIIDR8,1-AIIDSA,1-AIIDH1,1-AIIDWA,1-AIIDVS,1-AIIDWI,1-AIIDSI}
     recommendationstatuscheck.cronExpression: ${REC_STATUS_CHECK_CRON:0 0 * * * *}
+    nightlySyncStart.cronExpression: ${REC_STATUS_CHECK_CRON:0 0 * * * *}
     nightlySyncStartMessage: ${NIGHTLY_SYNC_START_MESSAGE:start}
 
   scheduling:

--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -76,6 +76,7 @@ app:
     gmcPassword: ${GMC_PASSWORD:guest}
     designatedBodies: ${DESIGNATED_BODY_CODE:1-AIIDHJ,1-AIIDMQ,1-AIIDNQ,1-AIIDMY,1-AIIDQQ,1-AIIDWT,1-AIIDR8,1-AIIDSA,1-AIIDH1,1-AIIDWA,1-AIIDVS,1-AIIDWI,1-AIIDSI}
     recommendationstatuscheck.cronExpression: ${REC_STATUS_CHECK_CRON:0 0 * * * *}
+    nightlySyncStartMessage: ${NIGHTLY_SYNC_START_MESSAGE:start}
 
   scheduling:
     lock:

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/controller/GmcDoctorSyncControllerTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/controller/GmcDoctorSyncControllerTest.java
@@ -24,7 +24,6 @@ package uk.nhs.hee.tis.revalidation.controller;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDate;
@@ -42,7 +41,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import uk.nhs.hee.tis.revalidation.entity.DoctorsForDB;
 import uk.nhs.hee.tis.revalidation.entity.RecommendationStatus;
 import uk.nhs.hee.tis.revalidation.entity.UnderNotice;
-import uk.nhs.hee.tis.revalidation.service.GmcDoctorSyncService;
+import uk.nhs.hee.tis.revalidation.service.GmcDoctorConnectionSyncService;
 
 @ExtendWith(MockitoExtension.class)
 @WebMvcTest(GmcDoctorSyncController.class)
@@ -53,7 +52,7 @@ class GmcDoctorSyncControllerTest {
   private MockMvc mockMvc;
 
   @MockBean
-  private GmcDoctorSyncService gmcDoctorSyncService;
+  private GmcDoctorConnectionSyncService gmcDoctorConnectionSyncService;
 
   @InjectMocks
   private GmcDoctorSyncController gmcDoctorSyncController;

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/messages/publisher/GmcDoctorsForDbSyncStartPublisherTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/messages/publisher/GmcDoctorsForDbSyncStartPublisherTest.java
@@ -35,7 +35,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class GmcDoctorsForDbSyncStartPublisherTest {
+class GmcDoctorsForDbSyncStartPublisherTest {
 
   @InjectMocks
   GmcDoctorsForDbSyncStartPublisher gmcDoctorsForDbSyncStartPublisher;
@@ -47,7 +47,7 @@ public class GmcDoctorsForDbSyncStartPublisherTest {
   ArgumentCaptor<String> messageCaptor;
 
   @Test
-  public void shouldPublishStartSyncMessage() {
+  void shouldPublishStartSyncMessage() {
 
     final String startMessage = "start";
     ReflectionTestUtils.setField(

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/messages/publisher/GmcDoctorsForDbSyncStartPublisherTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/messages/publisher/GmcDoctorsForDbSyncStartPublisherTest.java
@@ -19,37 +19,50 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.revalidation.service;
+package uk.nhs.hee.tis.revalidation.messages.publisher;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 @ExtendWith(MockitoExtension.class)
-class GmcDoctorSyncServiceTest {
+public class GmcDoctorsForDbSyncStartPublisherTest {
+
+  @InjectMocks
+  GmcDoctorsForDbSyncStartPublisher gmcDoctorsForDbSyncStartPublisher;
+
+  @Mock
+  MessagePublisher<String> messagePublisher;
 
   @Captor
-  ArgumentCaptor<String> syncStartMessage;
-  @Mock
-  private GmcDoctorSyncService gmcDoctorSyncService;
-
-  @BeforeEach
-  void setUp() {
-  }
+  ArgumentCaptor<String> messageCaptor;
 
   @Test
-  void testReceiveMessageArgument() {
-    gmcDoctorSyncService.receiveMessage("gmcSyncStart");
+  public void shouldPublishStartSyncMessage() {
 
-    verify(gmcDoctorSyncService).receiveMessage(syncStartMessage.capture());
-    assertThat(syncStartMessage.getValue(), is("gmcSyncStart"));
+    final String startMessage = "start";
+    ReflectionTestUtils.setField(
+        gmcDoctorsForDbSyncStartPublisher, "startMessage", startMessage
+    );
+
+    gmcDoctorsForDbSyncStartPublisher.publishNightlySyncStartMessage();
+
+    verify(messagePublisher).publishToBroker(
+        messageCaptor.capture()
+    );
+
+    assertThat(messageCaptor.getValue(), is(startMessage));
+
   }
+
+
 }

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/messages/publisher/RabbitMqMessagePublisherTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/messages/publisher/RabbitMqMessagePublisherTest.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.messages.publisher;
+
+import com.github.javafaker.Faker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class RabbitMqMessagePublisherTest {
+
+  private final Faker faker = new Faker();
+
+  @InjectMocks
+  RabbitMqMessagePublisher<String> rabbitMqMessagePublisher;
+
+  @Mock
+  RabbitTemplate rabbitTemplate;
+
+  @Captor
+  ArgumentCaptor<String> messageCaptor;
+
+  @Captor
+  ArgumentCaptor<String> exchangeNameCaptor;
+
+  @Captor
+  ArgumentCaptor<String> routingKeyNameCaptor;
+
+  private String gmcNumber = faker.number().digits(7);
+  private String gmcRecommendationId = faker.number().digits(3);
+  private String recommendationId = faker.number().digits(3);
+  private String designatedBody = faker.lorem().characters(5);
+
+  private String recommendationStatusCheckDto = "start";
+
+  @Test
+  public void shouldPublishToRabbitMq() {
+
+    String routingKeyName = "routingKeyName";
+    String exchangeName = "exchangeName";
+
+    ReflectionTestUtils.setField(
+        rabbitMqMessagePublisher, "routingKey", routingKeyName
+    );
+    ReflectionTestUtils.setField(
+        rabbitMqMessagePublisher, "exchange", exchangeName
+    );
+
+    rabbitMqMessagePublisher.publishToBroker(recommendationStatusCheckDto);
+
+    verify(rabbitTemplate).convertAndSend(
+        exchangeNameCaptor.capture(),
+        routingKeyNameCaptor.capture(),
+        messageCaptor.capture()
+    );
+
+    assertThat(messageCaptor.getValue(), is("start"));
+    assertThat(routingKeyNameCaptor.getValue(), is(routingKeyName));
+    assertThat(exchangeNameCaptor.getValue(), is(exchangeName));
+  }
+}
+

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/messages/publisher/RabbitMqMessagePublisherTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/messages/publisher/RabbitMqMessagePublisherTest.java
@@ -37,7 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class RabbitMqMessagePublisherTest {
+class RabbitMqMessagePublisherTest {
 
   private final Faker faker = new Faker();
 
@@ -64,7 +64,7 @@ public class RabbitMqMessagePublisherTest {
   private String recommendationStatusCheckDto = "start";
 
   @Test
-  public void shouldPublishToRabbitMq() {
+  void shouldPublishToRabbitMq() {
 
     String routingKeyName = "routingKeyName";
     String exchangeName = "exchangeName";

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBServiceTest.java
@@ -452,6 +452,14 @@ class DoctorsForDBServiceTest {
     assertThat(doctorCaptor.getValue().getDoctorStatus(), is(RecommendationStatus.COMPLETED));
   }
 
+  @Test
+  void shouldHideAllDoctorsByModifyingDBC() {
+    when(repository.findAll()).thenReturn(List.of(doc1));
+    doctorsForDBService.hideAllDoctors();
+    verify(repository).save(doctorCaptor.capture());
+    assertThat(doctorCaptor.getValue().getDesignatedBodyCode(), is("last-"+designatedBody1));
+  }
+
 
   private void setupData() {
     gmcRef1 = faker.number().digits(8);

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBServiceTest.java
@@ -460,6 +460,17 @@ class DoctorsForDBServiceTest {
     assertThat(doctorCaptor.getValue().getDesignatedBodyCode(), is("last-"+designatedBody1));
   }
 
+  @Test
+  void shouldNotAddHiddenPrefixToDoctorIfAlreadyHidden() {
+    final var dbCode = doc1.getDesignatedBodyCode();
+    doc1.setDesignatedBodyCode("last-" + dbCode);
+
+    when(repository.findAll()).thenReturn(List.of(doc1));
+    doctorsForDBService.hideAllDoctors();
+    verify(repository).save(doctorCaptor.capture());
+    assertThat(doctorCaptor.getValue().getDesignatedBodyCode(), is("last-"+designatedBody1));
+  }
+
 
   private void setupData() {
     gmcRef1 = faker.number().digits(8);

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorConnectionSyncServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorConnectionSyncServiceTest.java
@@ -23,33 +23,48 @@ package uk.nhs.hee.tis.revalidation.service;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.hee.tis.revalidation.repository.DoctorsForDBRepository;
+
 
 @ExtendWith(MockitoExtension.class)
 class GmcDoctorConnectionSyncServiceTest {
 
   @Captor
   ArgumentCaptor<String> syncStartMessage;
-  @Mock
+  @InjectMocks
   private GmcDoctorConnectionSyncService gmcDoctorConnectionSyncService;
+  @Mock
+  private QueueMessagingTemplate queueMessagingTemplate;
+  @Mock
+  private DoctorsForDBRepository doctorsForDBRepository;
 
   @BeforeEach
   void setUp() {
   }
 
   @Test
-  void testReceiveMessageArgument() {
+  void shouldRetrieveAllDoctors() {
     gmcDoctorConnectionSyncService.receiveMessage("gmcSyncStart");
 
-    verify(gmcDoctorConnectionSyncService).receiveMessage(syncStartMessage.capture());
-    assertThat(syncStartMessage.getValue(), is("gmcSyncStart"));
+    verify(doctorsForDBRepository).findAll();
+  }
+
+  @Test
+  void shouldNotRetireveDoctorsIfIncorrectMessageSupplied() {
+    gmcDoctorConnectionSyncService.receiveMessage("anyString");
+
+    verify(doctorsForDBRepository, never()).findAll();
   }
 }

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorConnectionSyncServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorConnectionSyncServiceTest.java
@@ -62,6 +62,13 @@ class GmcDoctorConnectionSyncServiceTest {
   }
 
   @Test
+  void shouldNotRetireveDoctorsIfNullMessageSupplied() {
+    gmcDoctorConnectionSyncService.receiveMessage(null);
+
+    verify(doctorsForDBRepository, never()).findAll();
+  }
+
+  @Test
   void shouldNotRetireveDoctorsIfIncorrectMessageSupplied() {
     gmcDoctorConnectionSyncService.receiveMessage("anyString");
 

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorConnectionSyncServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorConnectionSyncServiceTest.java
@@ -19,31 +19,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.revalidation.controller;
+package uk.nhs.hee.tis.revalidation.service;
 
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import uk.nhs.hee.tis.revalidation.service.GmcDoctorConnectionSyncService;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
 
-@Slf4j
-@RestController
-@RequestMapping("/api/v1/sqs")
-public class GmcDoctorSyncController {
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-  private final GmcDoctorConnectionSyncService gmcDoctorConnectionSyncService;
+@ExtendWith(MockitoExtension.class)
+class GmcDoctorConnectionSyncServiceTest {
 
-  public GmcDoctorSyncController(final GmcDoctorConnectionSyncService gmcDoctorConnectionSyncService) {
-    this.gmcDoctorConnectionSyncService = gmcDoctorConnectionSyncService;
+  @Captor
+  ArgumentCaptor<String> syncStartMessage;
+  @Mock
+  private GmcDoctorConnectionSyncService gmcDoctorConnectionSyncService;
+
+  @BeforeEach
+  void setUp() {
   }
 
-  @GetMapping("/send-doctor")
-  public ResponseEntity<Void> startGmcSync() {
-    //this endpoint is needed to start gmc sync manually
+  @Test
+  void testReceiveMessageArgument() {
     gmcDoctorConnectionSyncService.receiveMessage("gmcSyncStart");
-    return ResponseEntity.ok().build();
-  }
 
+    verify(gmcDoctorConnectionSyncService).receiveMessage(syncStartMessage.capture());
+    assertThat(syncStartMessage.getValue(), is("gmcSyncStart"));
+  }
 }

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorNightlySyncServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorNightlySyncServiceTest.java
@@ -31,7 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.hee.tis.revalidation.messages.publisher.GmcDoctorsForDbSyncStartPublisher;
 
 @ExtendWith(MockitoExtension.class)
-public class GmcDoctorNightlySyncServiceTest {
+class GmcDoctorNightlySyncServiceTest {
 
   @InjectMocks
   GmcDoctorNightlySyncService gmcDoctorNightlySyncService;
@@ -44,13 +44,13 @@ public class GmcDoctorNightlySyncServiceTest {
 
 
   @Test
-  public void shouldHideAllDoctors() {
+  void shouldHideAllDoctors() {
     gmcDoctorNightlySyncService.startNightlyGmcDoctorSync();
     verify(doctorsForDBService).hideAllDoctors();
   }
 
   @Test
-  public void shouldPublishMessageToStartSync() {
+  void shouldPublishMessageToStartSync() {
     gmcDoctorNightlySyncService.startNightlyGmcDoctorSync();
     verify(gmcDoctorsForDbSyncStartPublisher).publishNightlySyncStartMessage();
   }

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorNightlySyncServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorNightlySyncServiceTest.java
@@ -19,31 +19,40 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.revalidation.controller;
+package uk.nhs.hee.tis.revalidation.service;
 
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import uk.nhs.hee.tis.revalidation.service.GmcDoctorConnectionSyncService;
+import static org.mockito.Mockito.verify;
 
-@Slf4j
-@RestController
-@RequestMapping("/api/v1/sqs")
-public class GmcDoctorSyncController {
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.hee.tis.revalidation.messages.publisher.GmcDoctorsForDbSyncStartPublisher;
 
-  private final GmcDoctorConnectionSyncService gmcDoctorConnectionSyncService;
+@ExtendWith(MockitoExtension.class)
+public class GmcDoctorNightlySyncServiceTest {
 
-  public GmcDoctorSyncController(final GmcDoctorConnectionSyncService gmcDoctorConnectionSyncService) {
-    this.gmcDoctorConnectionSyncService = gmcDoctorConnectionSyncService;
+  @InjectMocks
+  GmcDoctorNightlySyncService gmcDoctorNightlySyncService;
+
+  @Mock
+  DoctorsForDBService doctorsForDBService;
+
+  @Mock
+  GmcDoctorsForDbSyncStartPublisher gmcDoctorsForDbSyncStartPublisher;
+
+
+  @Test
+  public void shouldHideAllDoctors() {
+    gmcDoctorNightlySyncService.startNightlyGmcDoctorSync();
+    verify(doctorsForDBService).hideAllDoctors();
   }
 
-  @GetMapping("/send-doctor")
-  public ResponseEntity<Void> startGmcSync() {
-    //this endpoint is needed to start gmc sync manually
-    gmcDoctorConnectionSyncService.receiveMessage("gmcSyncStart");
-    return ResponseEntity.ok().build();
+  @Test
+  public void shouldPublishMessageToStartSync() {
+    gmcDoctorNightlySyncService.startNightlyGmcDoctorSync();
+    verify(gmcDoctorsForDbSyncStartPublisher).publishNightlySyncStartMessage();
   }
 
 }


### PR DESCRIPTION
- Renamed GmcDoctorSyncService to GmcDoctorConnectionSyncService for obvious reasons
- Created new GmcDoctorNightlySyncService to be triggered by cron job
- GmcDoctorNightlySyncService calls new DoctorsForDbService method to "hide" all doctors then publishes message to kick off gmc sync
- Added cron job (schedule lock to prevent all instances firing(?)
-Added rabbit config
- What if gmc job fails? how do we recover the doctors? - **Simply Re-run, no need to "hide" GMC failure**