### PR TITLE
chore: update lister ack mode

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/RabbitMessageListener.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/RabbitMessageListener.java
@@ -88,7 +88,8 @@ public class RabbitMessageListener {
   /**
    * get trainee from Master index then update recommendation indexes.
    */
-  @RabbitListener(queues = "${app.rabbit.reval.queue.indexrebuildgetmastercommand.requested}")
+  @RabbitListener(queues = "${app.rabbit.reval.queue.indexrebuildgetmastercommand.requested}",
+      ackMode = "NONE")
   @SchedulerLock(name = "IndexRebuildGetMasterJob")
   public void receiveMessageGetMaster(final String getMaster) throws IOException {
     log.info("Message received to get trainee record from Master index.");

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorConnectionSyncService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/GmcDoctorConnectionSyncService.java
@@ -24,6 +24,7 @@ package uk.nhs.hee.tis.revalidation.service;
 import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -53,7 +54,8 @@ public class GmcDoctorConnectionSyncService {
     this.recommendationService = recommendationService;
   }
 
-  @RabbitListener(queues = "${app.rabbit.reval.queue.recommendation.syncstart}")
+  @RabbitListener(queues = "${app.rabbit.reval.queue.recommendation.syncstart}", ackMode = "NONE")
+  @SchedulerLock(name = "IndexRebuildGetGmcJob")
   public void receiveMessage(final String gmcSyncStart) {
     log.info("Message from integration service to start gmc sync {}", gmcSyncStart);
 


### PR DESCRIPTION
for queues `app.rabbit.reval.queue.indexrebuildgetmastercommand.requested` and `app.rabbit.reval.queue.recommendation.syncstart`,
ack will be sent immediately after message received, so message won't get stuck until job ends

TIS21-2669: Filter Recommendations with ES - Rebuild ES Job