### PR TITLE
fix: swagger config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ mvn clean verify -Pintegration-tests
 
 Above command will setup docker environment on your local machine before it execute integration tests from integration-tests module.
 
+# To access Swagger UI on local
+http://localhost:8080/revalidation/swagger-ui/index.html
 
 # Cron Jobs
 ## Gmc Nightly Doctor Sync (GmcDoctorNightlySyncService.startNightlyGmcDoctorSync)

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <mapstruct.version>1.4.2.Final</mapstruct.version>
+        <io.springfox.version>3.0.0</io.springfox.version>
     </properties>
 
     <dependencies>
@@ -68,12 +69,8 @@
 
         <dependency>
             <groupId>io.springfox</groupId>
-            <artifactId>springfox-swagger2</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-swagger-ui</artifactId>
+            <artifactId>springfox-boot-starter</artifactId>
+            <version>${io.springfox.version}</version>
         </dependency>
 
         <dependency>

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/config/SwaggerConfig.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/config/SwaggerConfig.java
@@ -38,11 +38,13 @@ public class SwaggerConfig {
 
   @Bean
   public Docket api() {
-    return new Docket(DocumentationType.SWAGGER_2).select()
+    return new Docket(DocumentationType.OAS_30)
+        .apiInfo(apiEndPointsInfo())
+        .select()
         .apis(RequestHandlerSelectors
             .basePackage("uk.nhs.hee.tis.revalidation.controller"))
         .paths(PathSelectors.regex("/.*"))
-        .build().apiInfo(apiEndPointsInfo());
+        .build();
   }
 
   private ApiInfo apiEndPointsInfo() {


### PR DESCRIPTION
The swagger UI doesn't work due to dependency incompatibility.  For Spring Version >= 2.2, we should use the dependency `springfox-boot-starter` (see: https://stackoverflow.com/questions/46151540/added-springfox-swagger-ui-and-its-not-working-what-am-i-missing).

After this fix, we will be able to access swagger UI on local: `http://localhost:8080/revalidation/swagger-ui/index.html`

TIS-SHED: no ticket