### PR TITLE
feat: support a dedicated programmeName filter

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/controller/DoctorsForDBController.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/controller/DoctorsForDBController.java
@@ -62,6 +62,7 @@ public class DoctorsForDBController {
   protected static final String SEARCH_QUERY = "searchQuery";
   protected static final String EMPTY_STRING = "";
   protected static final String DESIGNATED_BODY_CODES = "dbcs";
+  protected static final String PROGRAMME_NAME_PARAM = "programmeName";
 
   @Value("${app.validation.sort.fields}")
   private List<String> sortFields;
@@ -85,6 +86,7 @@ public class DoctorsForDBController {
       @RequestParam(name = UNDER_NOTICE, defaultValue = UNDER_NOTICE_VALUE, required = false) final boolean underNotice,
       @RequestParam(name = PAGE_NUMBER, defaultValue = PAGE_NUMBER_VALUE, required = false) final int pageNumber,
       @RequestParam(name = DESIGNATED_BODY_CODES, required = false) final List<String> dbcs,
+      @RequestParam(name = PROGRAMME_NAME_PARAM, required = false) final String programmeName,
       @RequestParam(name = SEARCH_QUERY, defaultValue = EMPTY_STRING, required = false) final String searchQuery) {
     final var traineeRequestDTO = TraineeRequestDto.builder()
         .sortColumn(sortColumn)
@@ -93,6 +95,7 @@ public class DoctorsForDBController {
         .pageNumber(pageNumber)
         .dbcs(dbcs)
         .searchQuery(searchQuery)
+        .programmeName(programmeName)
         .build();
 
     validate(traineeRequestDTO);

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/dto/TraineeRequestDto.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/dto/TraineeRequestDto.java
@@ -37,5 +37,6 @@ public class TraineeRequestDto {
   private boolean underNotice;
   private int pageNumber;
   private List<String> dbcs;
+  private String programmeName;
   private String searchQuery;
 }

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/repository/RecommendationElasticSearchRepository.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/repository/RecommendationElasticSearchRepository.java
@@ -34,16 +34,26 @@ public interface RecommendationElasticSearchRepository
     extends ElasticsearchRepository<RecommendationView, String> {
 
   @Query(
-      "{\"bool\":{\"filter\":[{\"match\":{\"underNotice\":\"YES\"}},{\"match\":{\"designatedBody\":\"?1\"}},{\"match\":{\"existsInGmc\":\"true\"}},{\"bool\":{\"should\":[{\"wildcard\":{\"doctorFirstName\":{\"value\":\"?0*\"}}},{\"wildcard\":{\"doctorLastName\":{\"value\":\"?0*\"}}},{\"wildcard\":{\"gmcReferenceNumber\":{\"value\":\"?0*\"}}},{\"match_phrase_prefix\":{\"programmeName\":{\"query\":\"?0\"}}}]}}]}}"
+      "{\"bool\":{\"filter\":[{\"match\":{\"underNotice\":\"YES\"}},{\"match\":"
+          + "{\"designatedBody\":\"?1\"}},{\"match\":{\"existsInGmc\":\"true\"}},{\"bool\":"
+          + "{\"should\":[{\"wildcard\":{\"doctorFirstName\":{\"value\":\"?0*\"}}},{\"wildcard\":"
+          + "{\"doctorLastName\":{\"value\":\"?0*\"}}},{\"wildcard\":{\"gmcReferenceNumber\":"
+          + "{\"value\":\"?0*\"}}}]}},{\"match_phrase\":{\"programmeName\":{\"query\":\"?2\","
+          + "\"zero_terms_query\":\"all\"}}}]}}"
   )
   Page<RecommendationView> findByUnderNotice(final String searchQuery,
-      final String dbcs, final Pageable pageable);
+      final String dbcs, String programmeName, final Pageable pageable);
 
   @Query(
-      "{\"bool\":{\"must_not\":{\"match\":{\"gmcReferenceNumber\":\"?2\"}},\"filter\":[{\"match\":{\"designatedBody\":\"?1\"}},{\"match\":{\"existsInGmc\":\"true\"}},{\"bool\":{\"should\":[{\"wildcard\":{\"doctorFirstName\":{\"value\":\"?0*\"}}},{\"wildcard\":{\"doctorLastName\":{\"value\":\"?0*\"}}},{\"wildcard\":{\"gmcReferenceNumber\":{\"value\":\"?0*\"}}},{\"match_phrase_prefix\":{\"programmeName\":{\"query\":\"?0\"}}}]}}]}}"
+      "{\"bool\":{\"must_not\":{\"match\":{\"gmcReferenceNumber\":\"?2\"}},\"filter\":"
+          + "[{\"match\":{\"designatedBody\":\"?1\"}},{\"match\":{\"existsInGmc\":\"true\"}},"
+          + "{\"bool\":{\"should\":[{\"wildcard\":{\"doctorFirstName\":{\"value\":\"?0*\"}}},"
+          + "{\"wildcard\":{\"doctorLastName\":{\"value\":\"?0*\"}}},{\"wildcard\":"
+          + "{\"gmcReferenceNumber\":{\"value\":\"?0*\"}}}]}},{\"match_phrase\":{\"programmeName\":"
+          + "{\"query\":\"?3\",\"zero_terms_query\":\"all\"}}}]}}"
   )
   Page<RecommendationView> findAll(final String searchQuery,
-      final String dbcs, List<String> hiddenGmcIds, final Pageable pageable);
+      final String dbcs, List<String> hiddenGmcIds, String programmeName, final Pageable pageable);
 
   List<RecommendationView> findByGmcReferenceNumber(String gmcReferenceNumber);
 

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
@@ -27,8 +27,8 @@ import static org.springframework.data.domain.PageRequest.of;
 import static org.springframework.data.domain.Sort.Direction.ASC;
 import static org.springframework.data.domain.Sort.Direction.DESC;
 import static org.springframework.data.domain.Sort.by;
-import static uk.nhs.hee.tis.revalidation.entity.UnderNotice.YES;
 import static uk.nhs.hee.tis.revalidation.entity.UnderNotice.NO;
+import static uk.nhs.hee.tis.revalidation.entity.UnderNotice.YES;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -91,9 +91,13 @@ public class DoctorsForDBService {
     final var traineeDoctors = doctorsList.stream()
         .map(recommendationViewMapper::toTraineeInfoDto).collect(toList());
 
-    return TraineeSummaryDto.builder().traineeInfo(traineeDoctors).countTotal(getCountAll())
-        .countUnderNotice(getCountUnderNotice()).totalPages(paginatedDoctors.getTotalPages())
-        .totalResults(paginatedDoctors.getTotalElements()).build();
+    return TraineeSummaryDto.builder()
+        .traineeInfo(traineeDoctors)
+        .countTotal(getCountAll())
+        .countUnderNotice(getCountUnderNotice())
+        .totalPages(paginatedDoctors.getTotalPages())
+        .totalResults(paginatedDoctors.getTotalElements())
+        .build();
   }
 
   public void updateTrainee(final DoctorsForDbDto gmcDoctor) {

--- a/application/src/main/resources/esjson/findAllUnderNotice.json
+++ b/application/src/main/resources/esjson/findAllUnderNotice.json
@@ -40,15 +40,16 @@
                     "value": "?0*"
                   }
                 }
-              },
-              {
-                "match_phrase_prefix": {
-                  "programmeName": {
-                    "query": "?0"
-                  }
-                }
               }
             ]
+          }
+        },
+        {
+          "match_phrase": {
+            "programmeName": {
+              "query": "?2",
+              "zero_terms_query": "all"
+            }
           }
         }
       ]

--- a/application/src/main/resources/esjson/findall.json
+++ b/application/src/main/resources/esjson/findall.json
@@ -40,15 +40,16 @@
                     "value": "?0*"
                   }
                 }
-              },
-              {
-                "match_phrase_prefix": {
-                  "programmeName": {
-                    "query": "?0"
-                  }
-                }
               }
             ]
+          }
+        },
+        {
+          "match_phrase": {
+            "programmeName": {
+              "query": "?3",
+              "zero_terms_query": "all"
+            }
           }
         }
       ]

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/controller/DoctorsForDBControllerTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/controller/DoctorsForDBControllerTest.java
@@ -21,7 +21,6 @@
 
 package uk.nhs.hee.tis.revalidation.controller;
 
-import static java.lang.String.format;
 import static java.time.LocalDate.now;
 import static java.util.List.of;
 import static org.hamcrest.Matchers.hasItem;
@@ -37,6 +36,7 @@ import static uk.nhs.hee.tis.revalidation.controller.DoctorsForDBController.DESI
 import static uk.nhs.hee.tis.revalidation.controller.DoctorsForDBController.EMPTY_STRING;
 import static uk.nhs.hee.tis.revalidation.controller.DoctorsForDBController.PAGE_NUMBER;
 import static uk.nhs.hee.tis.revalidation.controller.DoctorsForDBController.PAGE_NUMBER_VALUE;
+import static uk.nhs.hee.tis.revalidation.controller.DoctorsForDBController.PROGRAMME_NAME_PARAM;
 import static uk.nhs.hee.tis.revalidation.controller.DoctorsForDBController.SEARCH_QUERY;
 import static uk.nhs.hee.tis.revalidation.controller.DoctorsForDBController.SORT_COLUMN;
 import static uk.nhs.hee.tis.revalidation.controller.DoctorsForDBController.SORT_ORDER;
@@ -100,6 +100,7 @@ class DoctorsForDBControllerTest {
   private String designatedBody1, designatedBody2;
   private String connectionStatus1;
   private String connectionStatus2;
+  private String programmeName;
 
   @BeforeEach
   public void setup() {
@@ -124,6 +125,7 @@ class DoctorsForDBControllerTest {
     designatedBody2 = faker.lorem().characters(8);
     connectionStatus1 = faker.lorem().characters(3);
     connectionStatus2 = faker.lorem().characters(3);
+    programmeName = faker.backToTheFuture().quote();
   }
 
   @Test
@@ -131,17 +133,18 @@ class DoctorsForDBControllerTest {
     final var gmcDoctorDTO = prepareGmcDoctor();
     final var requestDTO = TraineeRequestDto.builder().sortOrder(ASC)
         .sortColumn(SUBMISSION_DATE).searchQuery(EMPTY_STRING)
-        .dbcs(List.of(designatedBody1, designatedBody2)).build();
+        .dbcs(List.of(designatedBody1, designatedBody2)).programmeName(programmeName).build();
     when(doctorsForDBService.getAllTraineeDoctorDetails(requestDTO, List.of()))
         .thenReturn(gmcDoctorDTO);
     final var dbcString = String.format("%s,%s", designatedBody1, designatedBody2);
     this.mockMvc.perform(get("/api/v1/doctors")
-        .param(SORT_ORDER, ASC)
-        .param(SORT_COLUMN, SUBMISSION_DATE)
-        .param(UNDER_NOTICE, UNDER_NOTICE_VALUE)
-        .param(PAGE_NUMBER, PAGE_NUMBER_VALUE)
-        .param(SEARCH_QUERY, EMPTY_STRING)
-        .param(DESIGNATED_BODY_CODES, dbcString))
+            .param(SORT_ORDER, ASC)
+            .param(SORT_COLUMN, SUBMISSION_DATE)
+            .param(UNDER_NOTICE, UNDER_NOTICE_VALUE)
+            .param(PAGE_NUMBER, PAGE_NUMBER_VALUE)
+            .param(SEARCH_QUERY, EMPTY_STRING)
+            .param(DESIGNATED_BODY_CODES, dbcString)
+            .param(PROGRAMME_NAME_PARAM, programmeName))
         .andExpect(status().isOk())
         .andExpect(content().json(mapper.writeValueAsString(gmcDoctorDTO)));
   }
@@ -155,14 +158,14 @@ class DoctorsForDBControllerTest {
     when(doctorsForDBService.getAllTraineeDoctorDetails(requestDTO, List.of(gmcRef1)))
         .thenReturn(gmcDoctorDTO);
     final var dbcString = String.format("%s,%s", designatedBody1, designatedBody2);
-    final var url = format("%s/%s", UNHIDDEN_DOCTORS_API_URL, gmcRef1);
+    final var url = String.format("%s/%s", UNHIDDEN_DOCTORS_API_URL, gmcRef1);
     this.mockMvc.perform(get(url)
-        .param(SORT_ORDER, ASC)
-        .param(SORT_COLUMN, SUBMISSION_DATE)
-        .param(UNDER_NOTICE, UNDER_NOTICE_VALUE)
-        .param(PAGE_NUMBER, PAGE_NUMBER_VALUE)
-        .param(SEARCH_QUERY, EMPTY_STRING)
-        .param(DESIGNATED_BODY_CODES, dbcString))
+            .param(SORT_ORDER, ASC)
+            .param(SORT_COLUMN, SUBMISSION_DATE)
+            .param(UNDER_NOTICE, UNDER_NOTICE_VALUE)
+            .param(PAGE_NUMBER, PAGE_NUMBER_VALUE)
+            .param(SEARCH_QUERY, EMPTY_STRING)
+            .param(DESIGNATED_BODY_CODES, dbcString))
         .andExpect(status().isOk())
         .andExpect(
             jsonPath("$.traineeInfo.[*].gmcReferenceNumber").value(hasItem(gmcRef2)));
@@ -178,9 +181,9 @@ class DoctorsForDBControllerTest {
     when(doctorsForDBService.getAllTraineeDoctorDetails(requestDTO, List.of()))
         .thenReturn(gmcDoctorDTO);
     this.mockMvc.perform(get("/api/v1/doctors")
-        .param(SORT_ORDER, "")
-        .param(SORT_COLUMN, "")
-        .param(DESIGNATED_BODY_CODES, dbcString))
+            .param(SORT_ORDER, "")
+            .param(SORT_COLUMN, "")
+            .param(DESIGNATED_BODY_CODES, dbcString))
         .andExpect(status().isOk())
         .andExpect(content().json(mapper.writeValueAsString(gmcDoctorDTO)));
   }
@@ -194,10 +197,10 @@ class DoctorsForDBControllerTest {
     final var dbcString = String.format("%s,%s", designatedBody1, designatedBody2);
     when(doctorsForDBService.getAllTraineeDoctorDetails(requestDTO, List.of()))
         .thenReturn(gmcDoctorDTO);
-    this.mockMvc.perform(get(DOCTORS_API_URL)
-        .param(SORT_ORDER, "aa")
-        .param(SORT_COLUMN, "date")
-        .param(DESIGNATED_BODY_CODES, dbcString))
+    mockMvc.perform(get(DOCTORS_API_URL)
+            .param(SORT_ORDER, "aa")
+            .param(SORT_COLUMN, "date")
+            .param(DESIGNATED_BODY_CODES, dbcString))
         .andExpect(status().isOk())
         .andExpect(content().json(mapper.writeValueAsString(gmcDoctorDTO)));
   }
@@ -211,11 +214,11 @@ class DoctorsForDBControllerTest {
     final var dbcString = String.format("%s,%s", designatedBody1, designatedBody2);
     when(doctorsForDBService.getAllTraineeDoctorDetails(requestDTO, List.of()))
         .thenReturn(gmcDoctorDTO);
-    this.mockMvc.perform(get(DOCTORS_API_URL)
-        .param(SORT_ORDER, ASC)
-        .param(SORT_COLUMN, SUBMISSION_DATE)
-        .param(UNDER_NOTICE, String.valueOf(true))
-        .param(DESIGNATED_BODY_CODES, dbcString))
+    mockMvc.perform(get(DOCTORS_API_URL)
+            .param(SORT_ORDER, ASC)
+            .param(SORT_COLUMN, SUBMISSION_DATE)
+            .param(UNDER_NOTICE, String.valueOf(true))
+            .param(DESIGNATED_BODY_CODES, dbcString))
         .andExpect(status().isOk())
         .andExpect(content().json(mapper.writeValueAsString(gmcDoctorDTO)));
   }
@@ -228,25 +231,25 @@ class DoctorsForDBControllerTest {
         .build();
     when(doctorsForDBService.getAllTraineeDoctorDetails(requestDTO, List.of()))
         .thenReturn(gmcDoctorDTO);
-    this.mockMvc.perform(get(DOCTORS_API_URL)
-        .param(SORT_ORDER, ASC)
-        .param(SORT_COLUMN, SUBMISSION_DATE)
-        .param(UNDER_NOTICE, String.valueOf(true)))
+    mockMvc.perform(get(DOCTORS_API_URL)
+            .param(SORT_ORDER, ASC)
+            .param(SORT_COLUMN, SUBMISSION_DATE)
+            .param(UNDER_NOTICE, String.valueOf(true)))
         .andExpect(status().isOk());
   }
 
 
   @Test
   void shouldUpdateAdminForTrainee() throws Exception {
-    final var url = format("%s/%s", DOCTORS_API_URL, UPDATE_ADMIN);
+    final var url = String.format("%s/%s", DOCTORS_API_URL, UPDATE_ADMIN);
     final var ta1 = TraineeAdminDto.builder().gmcNumber(gmcRef1).admin(admin).build();
     final var ta2 = TraineeAdminDto.builder().gmcNumber(gmcRef2).admin(admin).build();
     final var traineeAdminUpdateDto = TraineeAdminUpdateDto.builder()
         .traineeAdmins(of(ta1, ta2)).build();
-    this.mockMvc.perform(post(url)
-        .contentType(MediaType.APPLICATION_JSON)
-        .accept(MediaType.APPLICATION_JSON)
-        .content(mapper.writeValueAsString(traineeAdminUpdateDto)))
+    mockMvc.perform(post(url)
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+            .content(mapper.writeValueAsString(traineeAdminUpdateDto)))
         .andExpect(status().isOk());
   }
 
@@ -256,8 +259,8 @@ class DoctorsForDBControllerTest {
     final var designatedBodyDto = DesignatedBodyDto.builder().designatedBodyCode(designatedBody1)
         .build();
     when(doctorsForDBService.getDesignatedBodyCode(gmcRef1)).thenReturn(designatedBodyDto);
-    final var url = format("%s%s/%s", DOCTORS_API_URL, GET_DESIGNATED_BODY, gmcRef1);
-    this.mockMvc.perform(get(url))
+    final var url = String.format("%s%s/%s", DOCTORS_API_URL, GET_DESIGNATED_BODY, gmcRef1);
+    mockMvc.perform(get(url))
         .andExpect(content().json(mapper.writeValueAsString(designatedBodyDto)))
         .andExpect(status().isOk());
   }
@@ -266,8 +269,8 @@ class DoctorsForDBControllerTest {
   void shouldReturnDoctorsByGmcId() throws Exception {
     final var gmcDoctorDTO = prepareGmcDoctor();
     when(doctorsForDBService.getDoctorsByGmcIds(List.of(gmcRef1))).thenReturn(gmcDoctorDTO);
-    final var url = format("%s/%s", DOCTORS_API_URL_BY_GMC_ID, gmcRef1);
-    this.mockMvc.perform(get(url))
+    final var url = String.format("%s/%s", DOCTORS_API_URL_BY_GMC_ID, gmcRef1);
+    mockMvc.perform(get(url))
         .andExpect(content().json(mapper.writeValueAsString(gmcDoctorDTO)))
         .andExpect(status().isOk());
   }
@@ -277,7 +280,7 @@ class DoctorsForDBControllerTest {
     return TraineeSummaryDto.builder()
         .traineeInfo(doctorsForDB)
         .countTotal(doctorsForDB.size())
-        .countUnderNotice(1l)
+        .countUnderNotice(1L)
         .build();
   }
 

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBServiceTest.java
@@ -29,10 +29,9 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.data.domain.Sort.Direction.ASC;
-import static org.springframework.data.domain.Sort.Direction.DESC;
 import static org.springframework.data.domain.Sort.by;
-import static uk.nhs.hee.tis.revalidation.entity.UnderNotice.*;
+import static uk.nhs.hee.tis.revalidation.entity.UnderNotice.NO;
+import static uk.nhs.hee.tis.revalidation.entity.UnderNotice.YES;
 
 import com.github.javafaker.Faker;
 import java.time.LocalDate;
@@ -112,6 +111,7 @@ class DoctorsForDBServiceTest {
   private String designatedBody1, designatedBody2, designatedBody3, designatedBody4, designatedBody5;
   private String admin1, admin2, admin3, admin4, admin5;
   private String connectionStatus1, connectionStatus2, connectionStatus3, connectionStatus4, connectionStatus5;
+  private String programmeName;
 
   @BeforeEach
   public void setup() {
@@ -121,7 +121,7 @@ class DoctorsForDBServiceTest {
 
   @Test
   void shouldReturnListOfAllDoctors() {
-    List<Order> orders = new ArrayList<Order>();
+    List<Order> orders = new ArrayList<>();
     Order customOrder = new Order(Sort.Direction.DESC, "submissionDate");
     orders.add(customOrder);
     Order lastNameOrder = new Order(Sort.Direction.ASC, "doctorLastName");
@@ -132,21 +132,23 @@ class DoctorsForDBServiceTest {
         .of(designatedBody1, designatedBody2, designatedBody3, designatedBody4, designatedBody5);
     String formattedDbcs = String.join(",", dbcs);
     when(recommendationElasticSearchRepository
-        .findAll("", formattedDbcs, List.of(), pageableAndSortable)).thenReturn(page);
+        .findAll("", formattedDbcs, List.of(), programmeName, pageableAndSortable))
+        .thenReturn(page);
     when(recommendationElasticSearchService
         .formatDesignatedBodyCodesForElasticsearchQuery(dbcs)
     ).thenReturn(formattedDbcs);
 
     when(page.get()).thenReturn(Stream.of(rv1, rv2, rv3, rv4, rv5));
     when(page.getTotalPages()).thenReturn(1);
-    when(repository.countByUnderNoticeIn(YES)).thenReturn(2l);
-    when(repository.count()).thenReturn(5l);
+    when(repository.countByUnderNoticeIn(YES)).thenReturn(2L);
+    when(repository.count()).thenReturn(5L);
     final var requestDTO = TraineeRequestDto.builder()
         .sortOrder("desc")
         .sortColumn("submissionDate")
         .pageNumber(1)
         .searchQuery("")
         .dbcs(dbcs)
+        .programmeName(programmeName)
         .build();
 
     final var allDoctors = doctorsForDBService.getAllTraineeDoctorDetails(requestDTO, List.of());
@@ -196,7 +198,7 @@ class DoctorsForDBServiceTest {
 
   @Test
   void shouldReturnListOfDoctorsAttachedToASpecificDbc() {
-    List<Order> orders = new ArrayList<Order>();
+    List<Order> orders = new ArrayList<>();
     Order customOrder = new Order(Sort.Direction.DESC, "submissionDate");
     orders.add(customOrder);
     Order lastNameOrder = new Order(Sort.Direction.ASC, "doctorLastName");
@@ -206,20 +208,22 @@ class DoctorsForDBServiceTest {
     List<String> dbcs = List.of(designatedBody1);
     String formattedDbcs = String.join(",", dbcs);
     when(recommendationElasticSearchRepository
-        .findAll("", formattedDbcs, List.of(), pageableAndSortable)).thenReturn(page);
+        .findAll("", formattedDbcs, List.of(), programmeName, pageableAndSortable)).thenReturn(
+        page);
     when(recommendationElasticSearchService
         .formatDesignatedBodyCodesForElasticsearchQuery(dbcs)
     ).thenReturn(formattedDbcs);
     when(page.get()).thenReturn(Stream.of(rv1));
     when(page.getTotalPages()).thenReturn(1);
-    when(repository.countByUnderNoticeIn(YES)).thenReturn(2l);
-    when(repository.count()).thenReturn(5l);
+    when(repository.countByUnderNoticeIn(YES)).thenReturn(2L);
+    when(repository.count()).thenReturn(5L);
     final var requestDTO = TraineeRequestDto.builder()
         .sortOrder("desc")
         .sortColumn("submissionDate")
         .pageNumber(1)
         .searchQuery("")
         .dbcs(dbcs)
+        .programmeName(programmeName)
         .build();
 
     final var allDoctors = doctorsForDBService.getAllTraineeDoctorDetails(requestDTO, List.of());
@@ -241,7 +245,7 @@ class DoctorsForDBServiceTest {
   @Test
   void shouldReturnListOfUnderNoticeDoctors() {
 
-    List<Order> orders = new ArrayList<Order>();
+    List<Order> orders = new ArrayList<>();
     Order customOrder = new Order(Sort.Direction.DESC, "submissionDate");
     orders.add(customOrder);
     Order lastNameOrder = new Order(Sort.Direction.ASC, "doctorLastName");
@@ -251,14 +255,14 @@ class DoctorsForDBServiceTest {
         .of(designatedBody1, designatedBody2, designatedBody3, designatedBody4, designatedBody5);
     String formattedDbcs = String.join(",", dbcs);
     when(recommendationElasticSearchRepository
-        .findByUnderNotice("", formattedDbcs, pageableAndSortable)).thenReturn(page);
+        .findByUnderNotice("", formattedDbcs, programmeName, pageableAndSortable)).thenReturn(page);
     when(recommendationElasticSearchService
         .formatDesignatedBodyCodesForElasticsearchQuery(dbcs)
     ).thenReturn(formattedDbcs);
     when(page.get()).thenReturn(Stream.of(rv1, rv2));
     when(page.getTotalPages()).thenReturn(1);
-    when(repository.countByUnderNoticeIn(YES)).thenReturn(2l);
-    when(repository.count()).thenReturn(5l);
+    when(repository.countByUnderNoticeIn(YES)).thenReturn(2L);
+    when(repository.count()).thenReturn(5L);
     final var requestDTO = TraineeRequestDto.builder()
         .sortOrder("desc")
         .sortColumn("submissionDate")
@@ -266,6 +270,7 @@ class DoctorsForDBServiceTest {
         .pageNumber(1)
         .searchQuery("")
         .dbcs(dbcs)
+        .programmeName(programmeName)
         .build();
     final var allDoctors = doctorsForDBService.getAllTraineeDoctorDetails(requestDTO, List.of());
     final var doctorsForDB = allDoctors.getTraineeInfo();
@@ -292,7 +297,7 @@ class DoctorsForDBServiceTest {
 
   @Test
   void shouldReturnEmptyListOfDoctorsWhenNoRecordFound() {
-    List<Order> orders = new ArrayList<Order>();
+    List<Order> orders = new ArrayList<>();
     Order customOrder = new Order(Sort.Direction.DESC, "submissionDate");
     orders.add(customOrder);
     Order lastNameOrder = new Order(Sort.Direction.ASC, "doctorLastName");
@@ -303,18 +308,20 @@ class DoctorsForDBServiceTest {
         .of(designatedBody1, designatedBody2, designatedBody3, designatedBody4, designatedBody5);
     String formattedDbcs = String.join(",", dbcs);
     when(recommendationElasticSearchRepository
-        .findAll("", formattedDbcs, List.of(), pageableAndSortable)).thenReturn(page);
+        .findAll("", formattedDbcs, List.of(), programmeName, pageableAndSortable)).thenReturn(
+        page);
     when(recommendationElasticSearchService
         .formatDesignatedBodyCodesForElasticsearchQuery(dbcs)
     ).thenReturn(formattedDbcs);
     when(page.get()).thenReturn(Stream.of());
-    when(repository.countByUnderNoticeIn(YES)).thenReturn(0l);
+    when(repository.countByUnderNoticeIn(YES)).thenReturn(0L);
     final var requestDTO = TraineeRequestDto.builder()
         .sortOrder("desc")
         .sortColumn("submissionDate")
         .pageNumber(1)
         .searchQuery("")
         .dbcs(dbcs)
+        .programmeName(programmeName)
         .build();
     final var allDoctors = doctorsForDBService.getAllTraineeDoctorDetails(requestDTO, List.of());
     final var doctorsForDB = allDoctors.getTraineeInfo();
@@ -326,7 +333,7 @@ class DoctorsForDBServiceTest {
 
   @Test
   void shouldReturnListOfAllDoctorsWhoMatchSearchQuery() {
-    List<Order> orders = new ArrayList<Order>();
+    List<Order> orders = new ArrayList<>();
     Order customOrder = new Order(Sort.Direction.DESC, "submissionDate");
     orders.add(customOrder);
     Order lastNameOrder = new Order(Sort.Direction.ASC, "doctorLastName");
@@ -337,21 +344,23 @@ class DoctorsForDBServiceTest {
         .of(designatedBody1, designatedBody2, designatedBody3, designatedBody4, designatedBody5);
     String formattedDbcs = String.join(",", dbcs);
     when(recommendationElasticSearchRepository
-        .findAll("query", formattedDbcs, List.of(), pageableAndSortable)).thenReturn(page);
+        .findAll("query", formattedDbcs, List.of(), programmeName, pageableAndSortable))
+        .thenReturn(page);
     when(recommendationElasticSearchService
         .formatDesignatedBodyCodesForElasticsearchQuery(dbcs)
     ).thenReturn(formattedDbcs);
     when(page.get()).thenReturn(Stream.of(rv1, rv4));
     when(page.getTotalPages()).thenReturn(1);
-    when(page.getTotalElements()).thenReturn(2l);
-    when(repository.countByUnderNoticeIn(YES)).thenReturn(2l);
-    when(repository.count()).thenReturn(5l);
+    when(page.getTotalElements()).thenReturn(2L);
+    when(repository.countByUnderNoticeIn(YES)).thenReturn(2L);
+    when(repository.count()).thenReturn(5L);
     final var requestDTO = TraineeRequestDto.builder()
         .sortOrder("desc")
         .sortColumn("submissionDate")
         .pageNumber(1)
         .searchQuery("query")
         .dbcs(dbcs)
+        .programmeName(programmeName)
         .build();
     final var allDoctors = doctorsForDBService.getAllTraineeDoctorDetails(requestDTO, List.of());
     final var doctorsForDB = allDoctors.getTraineeInfo();
@@ -379,7 +388,7 @@ class DoctorsForDBServiceTest {
 
   @Test
   void shouldNotFailIfGmcIdNull() {
-    List<Order> orders = new ArrayList<Order>();
+    List<Order> orders = new ArrayList<>();
     Order customOrder = new Order(Sort.Direction.DESC, "submissionDate");
     orders.add(customOrder);
     Order lastNameOrder = new Order(Sort.Direction.ASC, "doctorLastName");
@@ -390,21 +399,22 @@ class DoctorsForDBServiceTest {
         .of(designatedBody1, designatedBody2, designatedBody3, designatedBody4, designatedBody5);
     String formattedDbcs = String.join(",", dbcs);
     when(recommendationElasticSearchRepository
-        .findAll("query", formattedDbcs, List.of(), pageableAndSortable)).thenReturn(page);
-    when(recommendationElasticSearchService
-        .formatDesignatedBodyCodesForElasticsearchQuery(dbcs)
-    ).thenReturn(formattedDbcs);
+        .findAll("query", formattedDbcs, List.of(), programmeName, pageableAndSortable))
+        .thenReturn(page);
+    when(recommendationElasticSearchService.formatDesignatedBodyCodesForElasticsearchQuery(dbcs))
+        .thenReturn(formattedDbcs);
     when(page.get()).thenReturn(Stream.of(rv1, rv4));
     when(page.getTotalPages()).thenReturn(1);
-    when(page.getTotalElements()).thenReturn(2l);
-    when(repository.countByUnderNoticeIn(YES)).thenReturn(2l);
-    when(repository.count()).thenReturn(5l);
+    when(page.getTotalElements()).thenReturn(2L);
+    when(repository.countByUnderNoticeIn(YES)).thenReturn(2L);
+    when(repository.count()).thenReturn(5L);
     final var requestDTO = TraineeRequestDto.builder()
         .sortOrder("desc")
         .sortColumn("submissionDate")
         .pageNumber(1)
         .searchQuery("query")
         .dbcs(dbcs)
+        .programmeName(programmeName)
         .build();
     final var allDoctors = doctorsForDBService.getAllTraineeDoctorDetails(requestDTO, null);
     final var doctorsForDB = allDoctors.getTraineeInfo();
@@ -432,7 +442,7 @@ class DoctorsForDBServiceTest {
 
   @Test
   void shouldNotApplySecondarySortIfSortByLastName() {
-    List<Order> orders = new ArrayList<Order>();
+    List<Order> orders = new ArrayList<>();
     Order customOrder = new Order(Sort.Direction.ASC, "doctorLastName");
     orders.add(customOrder);
 
@@ -441,21 +451,23 @@ class DoctorsForDBServiceTest {
         .of(designatedBody1, designatedBody2, designatedBody3, designatedBody4, designatedBody5);
     String formattedDbcs = String.join(",", dbcs);
     when(recommendationElasticSearchRepository
-        .findAll("query", formattedDbcs, List.of(), pageableAndSortable)).thenReturn(page);
+        .findAll("query", formattedDbcs, List.of(), programmeName, pageableAndSortable))
+        .thenReturn(page);
     when(recommendationElasticSearchService
         .formatDesignatedBodyCodesForElasticsearchQuery(dbcs)
     ).thenReturn(formattedDbcs);
     when(page.get()).thenReturn(Stream.of(rv1, rv4));
     when(page.getTotalPages()).thenReturn(1);
-    when(page.getTotalElements()).thenReturn(2l);
-    when(repository.countByUnderNoticeIn(YES)).thenReturn(2l);
-    when(repository.count()).thenReturn(5l);
+    when(page.getTotalElements()).thenReturn(2L);
+    when(repository.countByUnderNoticeIn(YES)).thenReturn(2L);
+    when(repository.count()).thenReturn(5L);
     final var requestDTO = TraineeRequestDto.builder()
         .sortOrder("asc")
         .sortColumn("doctorLastName")
         .pageNumber(1)
         .searchQuery("query")
         .dbcs(dbcs)
+        .programmeName(programmeName)
         .build();
     final var allDoctors = doctorsForDBService.getAllTraineeDoctorDetails(requestDTO, null);
     final var doctorsForDB = allDoctors.getTraineeInfo();
@@ -693,5 +705,6 @@ class DoctorsForDBServiceTest {
     docDto2.setGmcReferenceNumber(gmcRef1);
     docDto2.setUnderNotice(NO.value());
 
+    programmeName = Faker.instance().funnyName().name();
   }
 }


### PR DESCRIPTION
This is the first of new filters.
A limitation means searching by optional partial terms aren't supported.

The new controller parameters should be cleaned up later. It's not clear how multiple programmes will be supported.

chore(smell): resolve codestyle issues

TIS21-2722: Filter by programme name