### PR TITLE
Chore/make serializer test cleaner tis21 2722

### DIFF
--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/JsonSerializationTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/JsonSerializationTest.java
@@ -28,36 +28,24 @@ import static org.hamcrest.core.Is.is;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import uk.nhs.hee.tis.revalidation.controller.DoctorsForDBController;
 import uk.nhs.hee.tis.revalidation.dto.DoctorsForDbDto;
-import uk.nhs.hee.tis.revalidation.service.DoctorsForDBService;
-import uk.nhs.hee.tis.revalidation.service.RecommendationElasticSearchService;
 
-@ExtendWith(MockitoExtension.class)
-@WebMvcTest(DoctorsForDBController.class)
 class JsonSerializationTest {
 
-  @MockBean
-  private RecommendationElasticSearchService recommendationElasticSearchService;
-
-  @MockBean
-  private DoctorsForDBService mDoctorsForDbService;
-
-  @Autowired
-  private ObjectMapper mapper;
+  private final ObjectMapper mapper = (new RevalidationApplication()).objectMapper();
 
   @Test
   void testDateSerialization() throws JsonProcessingException {
     assertThat(mapper, is(notNullValue()));
 
-    final var doctor = DoctorsForDbDto.builder().doctorFirstName("first").doctorLastName("last")
-        .gmcReferenceNumber("gmtRef").sanction("sanction").underNotice("under notice")
-        .dateAdded("04/07/2017").submissionDate("04/07/2017").build();
+    final var doctor = DoctorsForDbDto.builder()
+        .doctorFirstName("first")
+        .doctorLastName("last")
+        .gmcReferenceNumber("gmtRef")
+        .sanction("sanction")
+        .underNotice("under notice")
+        .dateAdded("04/07/2017")
+        .submissionDate("04/07/2017").build();
 
     final var json = mapper.writeValueAsString(doctor);
 


### PR DESCRIPTION
This was primarily about removing the misnomer of `@WebMvcTest` when all it does is test whether the ObjectMapper bean serializes dates as expected.

There's an argument to be made that I've made it much more tied to current implementation which doesn't rely on additional config/spring context.