### PR TITLE
fix: Allow multiple gmc status search parameters for doctor search

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/repository/RecommendationElasticSearchRepository.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/repository/RecommendationElasticSearchRepository.java
@@ -38,7 +38,7 @@ public interface RecommendationElasticSearchRepository extends
       + "{\"should\":[{\"wildcard\":{\"doctorFirstName\":{\"value\":\"?0*\"}}},{\"wildcard\":"
       + "{\"doctorLastName\":{\"value\":\"?0*\"}}},{\"wildcard\":{\"gmcReferenceNumber\":"
       + "{\"value\":\"?0*\"}}}]}},{\"match_phrase\":{\"programmeName\":"
-      + "{\"query\":\"?2\",\"zero_terms_query\":\"all\"}}},{\"match_phrase\":"
+      + "{\"query\":\"?2\",\"zero_terms_query\":\"all\"}}},{\"match\":"
       + "{\"gmcStatus\":{\"query\":\"?3\",\"zero_terms_query\":\"all\"}}}]}}")
   Page<RecommendationView> findByUnderNotice(final String searchQuery, final String dbcs,
       String programmeName, String gmcStatus, final Pageable pageable);
@@ -48,7 +48,7 @@ public interface RecommendationElasticSearchRepository extends
       + "{\"bool\":{\"should\":[{\"wildcard\":{\"doctorFirstName\":{\"value\":\"?0*\"}}},"
       + "{\"wildcard\":{\"doctorLastName\":{\"value\":\"?0*\"}}},{\"wildcard\":"
       + "{\"gmcReferenceNumber\":{\"value\":\"?0*\"}}}]}},{\"match_phrase\":{\"programmeName\":"
-      + "{\"query\":\"?3\",\"zero_terms_query\":\"all\"}}},{\"match_phrase\":{\"gmcStatus\":"
+      + "{\"query\":\"?3\",\"zero_terms_query\":\"all\"}}},{\"match\":{\"gmcStatus\":"
       + "{\"query\":\"?4\",\"zero_terms_query\":\"all\"}}}]}}")
   Page<RecommendationView> findAll(final String searchQuery, final String dbcs,
       List<String> hiddenGmcIds, String programmeName, String gmcStatus, final Pageable pageable);

--- a/application/src/main/resources/esjson/findAllUnderNotice.json
+++ b/application/src/main/resources/esjson/findAllUnderNotice.json
@@ -53,7 +53,7 @@
           }
         },
         {
-          "match_phrase": {
+          "match": {
             "gmcStatus": {
               "query": "?3",
               "zero_terms_query": "all"

--- a/application/src/main/resources/esjson/findall.json
+++ b/application/src/main/resources/esjson/findall.json
@@ -53,7 +53,7 @@
           }
         },
         {
-          "match_phrase": {
+          "match": {
             "gmcStatus": {
               "query": "?4",
               "zero_terms_query": "all"


### PR DESCRIPTION
TIS21-3554: Change existing query in ES to include GMC status as separate parameters