### PR TITLE
chore:use mapping json for recommendationindex

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/entity/RecommendationView.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/entity/RecommendationView.java
@@ -36,12 +36,14 @@ import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Mapping;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Data
-@Document(indexName = "recommendationindex")
+@Document(indexName = "recommendationindex", createIndex = false)
+@Mapping(mappingPath = "/esjson/index_settings/recommendationindex.json")
 public class RecommendationView {
 
   @Id

--- a/application/src/main/resources/esjson/index_settings/recommendationindex.json
+++ b/application/src/main/resources/esjson/index_settings/recommendationindex.json
@@ -1,0 +1,106 @@
+{
+  "properties": {
+    "_class": {
+      "type": "keyword",
+      "index": false,
+      "doc_values": false
+    },
+    "admin": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        }
+      }
+    },
+    "curriculumEndDate": {
+      "type": "date",
+      "format": "uuuu-MM-dd"
+    },
+    "designatedBody": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        }
+      }
+    },
+    "doctorFirstName": {
+      "type": "text",
+      "fielddata": true
+    },
+    "doctorLastName": {
+      "type": "text",
+      "fielddata": true
+    },
+    "existsInGmc": {
+      "type": "boolean"
+    },
+    "gmcReferenceNumber": {
+      "type": "text",
+      "fielddata": true
+    },
+    "gmcStatus": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        }
+      }
+    },
+    "id": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        }
+      }
+    },
+    "lastUpdatedDate": {
+      "type": "date",
+      "format": "uuuu-MM-dd"
+    },
+    "membershipType": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        }
+      }
+    },
+    "programmeName": {
+      "type": "text",
+      "fielddata": true
+    },
+    "submissionDate": {
+      "type": "date",
+      "format": "uuuu-MM-dd"
+    },
+    "tcsPersonId": {
+      "type": "long"
+    },
+    "tisStatus": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        }
+      }
+    },
+    "underNotice": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
1. We can use the json file of mapping for recommendationindex. 
 `@Mapping` above the `RecommendationView` class has higher priority than the `@Field` annotation for each of the attributes. So `@Field` will all be ignored.

2. For annotation `@Document`, the attibute `createIndex` is default to true, which means, if `recommendationindex` doesn't exist in ES (either as an index name or an alias), the index will be created when this project is bootstrapping. I'm just thinking it may be better to turn it off if we're going to use alias.


TIS21-3416