### PR TITLE
fix: draft recommendation status to show correct value

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceImpl.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceImpl.java
@@ -291,12 +291,6 @@ public class RecommendationServiceImpl implements RecommendationService {
     //Check draft recommendation: if yes return draft else normal original flow
     if (draftRecommendations.size() > 0) {
       final var draftRecommendation = draftRecommendations.get(0);
-      //Edge case: check if the Recommendation is submitted by other means, i.e., GMC Connect
-      //if GMC submission date is past and ignore it, i.e. return empty TraineeRecommendationRecordDto
-      if (draftRecommendation.getGmcSubmissionDate().isBefore(LocalDate.now())) {
-        return new TraineeRecommendationRecordDto();
-      }
-      draftRecommendation.setRecommendationStatus(RecommendationStatus.DRAFT);
       return buildTraineeRecommendationRecordDto(draftRecommendation.getGmcNumber(),
           draftRecommendation.getGmcSubmissionDate(), draftRecommendation);
     } else {

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceImpl.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceImpl.java
@@ -283,7 +283,6 @@ public class RecommendationServiceImpl implements RecommendationService {
    */
   public TraineeRecommendationRecordDto getLatestRecommendation(String gmcId) {
     log.info("Fetching latest recommendation info for GmcId: {}", gmcId);
-    final var optionalDoctorsForDB = doctorsForDBRepository.findById(gmcId);
     final var recommendations = recommendationRepository.findByGmcNumber(gmcId);
     final var draftRecommendations = recommendations.stream().filter(
         recommendation -> recommendation.getRecommendationStatus().name().equals("READY_TO_REVIEW"))
@@ -294,6 +293,7 @@ public class RecommendationServiceImpl implements RecommendationService {
       return buildTraineeRecommendationRecordDto(draftRecommendation.getGmcNumber(),
           draftRecommendation.getGmcSubmissionDate(), draftRecommendation);
     } else {
+      final var optionalDoctorsForDB = doctorsForDBRepository.findById(gmcId);
       final var optionalRecommendation = recommendationRepository
           .findFirstByGmcNumberOrderByActualSubmissionDateDesc(gmcId);
       if (!optionalDoctorsForDB.isPresent()) {

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceImpl.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceImpl.java
@@ -288,7 +288,7 @@ public class RecommendationServiceImpl implements RecommendationService {
         recommendation -> recommendation.getRecommendationStatus().name().equals("READY_TO_REVIEW"))
         .collect(Collectors.toList());
     //Check draft recommendation: if yes return draft else normal original flow
-    if (draftRecommendations.size() > 0) {
+    if (!draftRecommendations.isEmpty()) {
       final var draftRecommendation = draftRecommendations.get(0);
       return buildTraineeRecommendationRecordDto(draftRecommendation.getGmcNumber(),
           draftRecommendation.getGmcSubmissionDate(), draftRecommendation);

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceTest.java
@@ -818,52 +818,10 @@ class RecommendationServiceTest {
     assertThat(traineeRecommendationRecordDto.getComments(), is(comments));
     assertThat(traineeRecommendationRecordDto.getAdmin(), is(admin1));
     assertThat(traineeRecommendationRecordDto.getRecommendationStatus(),
-        is(draftRecommendationStatus.name()));
+        is(draftRecommendationInitialStatus.name()));
 
     traineeRecommendationRecordDto = actualRecommendationMap.get(gmcNumberX);
     assertThat(traineeRecommendationRecordDto.getGmcNumber(), is(nullValue()));
-  }
-
-  //This test is for to check if the Recommendation is submitted by other means, i.e., GMC Connect
-  @Test
-  void shouldCheckDraftRecommendationIsAlreadySubmitted() {
-    final var gmcNumber2 = faker.number().digits(7);
-    final var gmcNumberX = faker.number().digits(7);
-
-    final var recommendation = Recommendation.builder()
-        .id(recommendationId)
-        .gmcNumber(gmcNumber1)
-        .recommendationStatus(draftRecommendationInitialStatus)
-        .recommendationType(RecommendationType.REVALIDATE)
-        .admin(admin1)
-        .gmcRevalidationId(gmcRecommendationId2)
-        .gmcSubmissionDate(gmcSubmissionDate)
-        .actualSubmissionDate(actualSubmissionDate)
-        //.outcome(outcome)
-        .comments(comments)
-        .build();
-    final var draftRecommendations = List.of(recommendation);
-
-    when(doctorsForDBRepository.findById(any())).thenReturn(Optional.of(doctorsForDB1));
-    when(recommendationRepository.findByGmcNumber(gmcNumber1))
-        .thenReturn(draftRecommendations);
-
-    final var actualRecommendationMap = recommendationService
-        .getLatestRecommendations(List.of(gmcNumber1, gmcNumberX, gmcNumber2));
-
-    assertThat(actualRecommendationMap.size(), is(3));
-
-    var traineeRecommendationRecordDto = actualRecommendationMap.get(gmcNumber1);
-    assertThat(traineeRecommendationRecordDto.getGmcNumber(), is(nullValue()));
-    assertThat(traineeRecommendationRecordDto.getGmcSubmissionDate(), is(nullValue()));
-    assertThat(traineeRecommendationRecordDto.getActualSubmissionDate(), is(nullValue()));
-    assertThat(traineeRecommendationRecordDto.getComments(), is(nullValue()));
-    assertThat(traineeRecommendationRecordDto.getAdmin(), is(nullValue()));
-    assertThat(traineeRecommendationRecordDto.getRecommendationStatus(), is(nullValue()));
-
-    traineeRecommendationRecordDto = actualRecommendationMap.get(gmcNumberX);
-    assertThat(traineeRecommendationRecordDto.getGmcNumber(), is(nullValue()));
-
   }
 
   @Test

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceTest.java
@@ -38,6 +38,7 @@ import static uk.nhs.hee.tis.revalidation.entity.GmcResponseCode.SUCCESS;
 import static uk.nhs.hee.tis.revalidation.entity.RecommendationGmcOutcome.APPROVED;
 import static uk.nhs.hee.tis.revalidation.entity.RecommendationGmcOutcome.REJECTED;
 import static uk.nhs.hee.tis.revalidation.entity.RecommendationGmcOutcome.UNDER_REVIEW;
+import static uk.nhs.hee.tis.revalidation.entity.RecommendationStatus.COMPLETED;
 import static uk.nhs.hee.tis.revalidation.entity.RecommendationStatus.DRAFT;
 import static uk.nhs.hee.tis.revalidation.entity.RecommendationStatus.NOT_STARTED;
 import static uk.nhs.hee.tis.revalidation.entity.RecommendationStatus.READY_TO_REVIEW;
@@ -137,7 +138,6 @@ class RecommendationServiceTest {
   private String designatedBodyCode;
   private RecommendationStatus status;
   private RecommendationStatus draftRecommendationInitialStatus;
-  private RecommendationStatus draftRecommendationStatus;
 
   private String deferralComment1, deferralComment2;
   private LocalDate deferralDate1, deferralDate2;
@@ -169,7 +169,6 @@ class RecommendationServiceTest {
 
   private DoctorsForDB doctorsForDB1, doctorsForDB2, doctorsForDB3;
 
-  private LocalDate gmcSubmissionDate;
   private final LocalDate actualsSubmissionDate1 = LocalDate.now();
   private final LocalDate actualsSubmissionDate2 = LocalDate.now().minusMonths(1);
   private final LocalDate actualsSubmissionDate3 = LocalDate.now().minusYears(1);
@@ -193,8 +192,6 @@ class RecommendationServiceTest {
     lastName = faker.name().lastName();
     status = NOT_STARTED;
     draftRecommendationInitialStatus = READY_TO_REVIEW;
-    draftRecommendationStatus = DRAFT;
-    gmcSubmissionDate = LocalDate.now().minusDays(10);
     submissionDate = LocalDate.now();
     actualSubmissionDate = LocalDate.now();
     dateAdded = LocalDate.now();
@@ -795,23 +792,22 @@ class RecommendationServiceTest {
   }
 
   @Test
-  void shouldCheckDraftRecommendations() {
-    final var gmcNumber2 = faker.number().digits(7);
-    final var gmcNumberX = faker.number().digits(7);
+  void shouldCheckDraftRecommendation() {
+    //Test case for one draft recommendation and one Completed recommendation
     final var recommendation = buildRecommendation(gmcNumber1, recommendationId,
         draftRecommendationInitialStatus,
         UNDER_REVIEW);
-    final var draftRecommendations = List.of(recommendation);
+    final var recommendation1 = buildRecommendation(gmcNumber1, gmcRecommendationId1,
+        COMPLETED,
+        APPROVED);
+    final var recommendations = List.of(recommendation, recommendation1);
 
-    when(doctorsForDBRepository.findById(any())).thenReturn(Optional.of(doctorsForDB1));
     when(recommendationRepository.findByGmcNumber(gmcNumber1))
-        .thenReturn(draftRecommendations);
-    final var actualRecommendationMap = recommendationService
-        .getLatestRecommendations(List.of(gmcNumber1, gmcNumberX, gmcNumber2));
+        .thenReturn(recommendations);
 
-    assertThat(actualRecommendationMap.size(), is(3));
+    final var traineeRecommendationRecordDto = recommendationService
+        .getLatestRecommendation(gmcNumber1);
 
-    var traineeRecommendationRecordDto = actualRecommendationMap.get(gmcNumber1);
     assertThat(traineeRecommendationRecordDto.getGmcNumber(), is(gmcNumber1));
     assertThat(traineeRecommendationRecordDto.getGmcSubmissionDate(), is(submissionDate));
     assertThat(traineeRecommendationRecordDto.getActualSubmissionDate(), is(actualSubmissionDate));
@@ -819,9 +815,6 @@ class RecommendationServiceTest {
     assertThat(traineeRecommendationRecordDto.getAdmin(), is(admin1));
     assertThat(traineeRecommendationRecordDto.getRecommendationStatus(),
         is(draftRecommendationInitialStatus.name()));
-
-    traineeRecommendationRecordDto = actualRecommendationMap.get(gmcNumberX);
-    assertThat(traineeRecommendationRecordDto.getGmcNumber(), is(nullValue()));
   }
 
   @Test
@@ -1014,15 +1007,6 @@ class RecommendationServiceTest {
 
   @Test
   void shouldSendRecommendationStatusRequestToRabbit() {
-
-//    final var doctorsForDB = doctorsForDBRepository.findById(rec.getGmcNumber());
-//    if (doctorsForDB.isPresent() && rec.getGmcRevalidationId() != null) {
-//      final var recommendationStatusDto = RecommendationStatusCheckDto.builder()
-//          .designatedBodyId(doctorsForDB.get().getDesignatedBodyCode())
-//          .gmcReferenceNumber(rec.getGmcNumber())
-//          .gmcRecommendationId(rec.getGmcRevalidationId())
-//          .recommendationId(rec.getId())
-//          .build();
     final Recommendation recommendationCheck = Recommendation.builder()
         .id(recommendationId)
         .gmcNumber(gmcNumber1)


### PR DESCRIPTION
- Check draft recommendation: if yes return draft else normal **_original_** flow
- Edge case: check if the Recommendation is submitted by other means, i.e., GMC Connect (if GMC submission date is past and ignore it, i.e. return empty TraineeRecommendationRecordDto)