### PR TITLE
feat: Allow override for whole Mongo URI

### DIFF
--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
       uris: ${ES_URLS:http://localhost:9200}
   data:
     mongodb:
-      uri: mongodb://${MONGODB_USERNAME:root}:${MONGODB_PASSWORD:password}@${MONGODB_HOST:localhost}:${MONGODB_PORT:27017}/${MONGODB_DATABASE:revalidation}?authSource=admin&authMechanism=SCRAM-SHA-1&replicaSet=rs0&readPreference=secondaryPreferred
+      uri: ${MONGODB_URI:mongodb://${MONGODB_USERNAME:root}:${MONGODB_PASSWORD:password}@${MONGODB_HOST:localhost}:${MONGODB_PORT:27017}/${MONGODB_DATABASE:revalidation}?authSource=admin&authMechanism=SCRAM-SHA-1&replicaSet=rs0&readPreference=secondaryPreferred}
 
 server:
   servlet:

--- a/integration-tests/src/test/resources/application-test.yml
+++ b/integration-tests/src/test/resources/application-test.yml
@@ -11,9 +11,13 @@ spring:
     port: ${RABBITMQ_PORT:5672}
     username: ${RABBITMQ_USERNAME:guest}
     password: ${RABBITMQ_PASSWORD:guest}
+    ssl.enabled: ${RABBITMQ_USE_SSL:false}
+  elasticsearch:
+    rest:
+      uris: ${ES_URLS:https://localhost:9200}
   data:
     mongodb:
-      uri: mongodb://${MONGODB_USERNAME:root}:${MONGODB_PASSWORD:password}@${MONGODB_HOST:localhost}:${MONGODB_PORT:27017}/${MONGODB_DATABASE:revalidation}?authSource=admin&authMechanism=SCRAM-SHA-1
+      uri: ${MONGODB_URI:mongodb://${MONGODB_USERNAME:root}:${MONGODB_PASSWORD:password}@${MONGODB_HOST:localhost}:${MONGODB_PORT:27017}/${MONGODB_DATABASE:revalidation}?authSource=admin&authMechanism=SCRAM-SHA-1}
 
 server:
   servlet:


### PR DESCRIPTION
Required for simplicity of testing against non-replicaset instances.

This doesn't follow the pattern of defining EVERYTHING in cloud config. I never thought it was sensible and would rather define what goes where.

TIS21-3880: Test Message Consumer Issue