### PR TITLE
chore: update parameter store location for dbcs in task definitions

### DIFF
--- a/.aws/task-definition-prod.json
+++ b/.aws/task-definition-prod.json
@@ -81,7 +81,7 @@
         },
         {
           "name": "DESIGNATED_BODY_CODE",
-          "valueFrom": "reval-gmc-designated-bodies-codes"
+          "valueFrom": "tis-revalidation-prod-gmc-designated-bodies-codes"
         },
         {
           "name": "SENTRY_DSN",

--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -85,7 +85,7 @@
         },
         {
           "name": "DESIGNATED_BODY_CODE",
-          "valueFrom": "reval-gmc-designated-bodies-codes"
+          "valueFrom": "tis-revalidation-preprod-gmc-designated-bodies-codes"
         },
         {
           "name": "SENTRY_DSN",


### PR DESCRIPTION
TIS21-4255: Add the new DBCs to parameter store to map to the Recommendation (update TaskDef)