### PR TITLE
fix: patch fix to remove commas from designated body es query

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationElasticSearchService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationElasticSearchService.java
@@ -80,7 +80,7 @@ public class RecommendationElasticSearchService {
     designatedBodyCodes.forEach(code -> {
       escapedCodes.add(code.toLowerCase().replace("1-", ""));
     });
-    return String.join(",", escapedCodes);
+    return String.join(" ", escapedCodes);
   }
 
   public List<String> getAutocompleteResults(String fieldname, String input, List<String> dbcs) {

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBServiceTest.java
@@ -134,7 +134,7 @@ class DoctorsForDBServiceTest {
     final Pageable pageableAndSortable = PageRequest.of(1, 20, by(orders));
     List<String> dbcs = List
         .of(designatedBody1, designatedBody2, designatedBody3, designatedBody4, designatedBody5);
-    String formattedDbcs = String.join(",", dbcs);
+    String formattedDbcs = String.join(" ", dbcs);
     when(recommendationElasticSearchRepository
         .findAll("", formattedDbcs, List.of(), programmeName, outcome1, status1.name(), admin1, pageableAndSortable))
         .thenReturn(page);
@@ -190,7 +190,7 @@ class DoctorsForDBServiceTest {
 
     final Pageable pageableAndSortable = PageRequest.of(1, 20, by(orders));
     List<String> dbcs = List.of(designatedBody1);
-    String formattedDbcs = String.join(",", dbcs);
+    String formattedDbcs = String.join(" ", dbcs);
     when(recommendationElasticSearchRepository
         .findAll("", formattedDbcs, List.of(), programmeName, outcome1, status1.name(), admin1, pageableAndSortable)).thenReturn(
         page);
@@ -240,7 +240,7 @@ class DoctorsForDBServiceTest {
     final Pageable pageableAndSortable = PageRequest.of(1, 20, by(orders));
     List<String> dbcs = List
         .of(designatedBody1, designatedBody2, designatedBody3, designatedBody4, designatedBody5);
-    String formattedDbcs = String.join(",", dbcs);
+    String formattedDbcs = String.join(" ", dbcs);
     when(recommendationElasticSearchRepository
         .findByUnderNotice("", formattedDbcs, programmeName, outcome1, status1.name(), admin1, pageableAndSortable)).thenReturn(page);
     when(recommendationElasticSearchService
@@ -296,7 +296,7 @@ class DoctorsForDBServiceTest {
     final Pageable pageableAndSortable = PageRequest.of(1, 20, by(orders));
     List<String> dbcs = List
         .of(designatedBody1, designatedBody2, designatedBody3, designatedBody4, designatedBody5);
-    String formattedDbcs = String.join(",", dbcs);
+    String formattedDbcs = String.join(" ", dbcs);
     when(recommendationElasticSearchRepository
         .findAll("", formattedDbcs, List.of(), programmeName, outcome1, status1.name(), admin1, pageableAndSortable)).thenReturn(
         page);
@@ -335,7 +335,7 @@ class DoctorsForDBServiceTest {
     final Pageable pageableAndSortable = PageRequest.of(1, 20, by(orders));
     List<String> dbcs = List
         .of(designatedBody1, designatedBody2, designatedBody3, designatedBody4, designatedBody5);
-    String formattedDbcs = String.join(",", dbcs);
+    String formattedDbcs = String.join(" ", dbcs);
     when(recommendationElasticSearchRepository
         .findAll("query", formattedDbcs, List.of(), programmeName, outcome1, status1.name(), admin1, pageableAndSortable))
         .thenReturn(page);
@@ -393,7 +393,7 @@ class DoctorsForDBServiceTest {
     final Pageable pageableAndSortable = PageRequest.of(1, 20, by(orders));
     List<String> dbcs = List
         .of(designatedBody1, designatedBody2, designatedBody3, designatedBody4, designatedBody5);
-    String formattedDbcs = String.join(",", dbcs);
+    String formattedDbcs = String.join(" ", dbcs);
     when(recommendationElasticSearchRepository
         .findAll("query", formattedDbcs, List.of(), programmeName, outcome1, status1.name(), admin1, pageableAndSortable))
         .thenReturn(page);
@@ -448,7 +448,7 @@ class DoctorsForDBServiceTest {
     final Pageable pageableAndSortable = PageRequest.of(1, 20, by(orders));
     List<String> dbcs = List
         .of(designatedBody1, designatedBody2, designatedBody3, designatedBody4, designatedBody5);
-    String formattedDbcs = String.join(",", dbcs);
+    String formattedDbcs = String.join(" ", dbcs);
     when(recommendationElasticSearchRepository
         .findAll("query", formattedDbcs, List.of(), programmeName, outcome1, status1.name(), admin1, pageableAndSortable))
         .thenReturn(page);

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/RecommendationElasticSearchServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/RecommendationElasticSearchServiceTest.java
@@ -128,7 +128,7 @@ class RecommendationElasticSearchServiceTest {
   void shouldFormatDesignatedBodyCodesForElasticsearchQuery() {
     final String dbc1 = "1-AIIDHJ";
     final String dbc2 = "AIIDMQ";
-    final String dbcformatted = "aiidhj,aiidmq";
+    final String dbcformatted = "aiidhj aiidmq";
     List<String> dbcs = List.of(dbc1, dbc2);
 
     final var result = recommendationElasticSearchService.formatDesignatedBodyCodesForElasticsearchQuery(


### PR DESCRIPTION
TIS21-4341: No summary doctors records returned by Elasticsearch with certain combinations of alphanumeric DBC codes