### PR TITLE
fix:set correct DBC to null for gmc sync

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
@@ -156,7 +156,7 @@ public class DoctorsForDBService {
     List<DoctorsForDB> doctors = doctorsRepository.findAll();
     doctors.forEach(doctor -> {
       doctor.setExistsInGmc(false);
-      doctor.setGmcReferenceNumber(null);
+      doctor.setDesignatedBodyCode(null);
       doctorsRepository.save(doctor);
     });
   }

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBServiceTest.java
@@ -565,7 +565,7 @@ class DoctorsForDBServiceTest {
     verify(repository).save(doctorCaptor.capture());
     DoctorsForDB doctor = doctorCaptor.getValue();
     assertThat(doctor.getExistsInGmc(), is(false));
-    assertThat(doctor.getGmcReferenceNumber(), nullValue());
+    assertThat(doctor.getDesignatedBodyCode(), nullValue());
   }
 
   @Test


### PR DESCRIPTION
In the last PR, I used the incorrect field (gmcReferenceNumber 😭 ). So fix it here.

TIS21-4510