### PR TITLE
fix: ignore unknown gmc number when finding elasticsearch views

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationElasticSearchService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationElasticSearchService.java
@@ -119,7 +119,7 @@ public class RecommendationElasticSearchService {
     Iterable<RecommendationView> result = new ArrayList<>();
     if (gmcReferenceNumber == null) {
       throw new NullPointerException("gmcReferenceNumber is null");
-    } else if (gmcReferenceNumber.toLowerCase().equals("unknown")){
+    } else if (gmcReferenceNumber.equalsIgnoreCase("unknown")){
       LOG.debug("CDC Skipped for doctor with GMC reference number: UNKNOWN");
     }
     else {

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationElasticSearchService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationElasticSearchService.java
@@ -119,7 +119,10 @@ public class RecommendationElasticSearchService {
     Iterable<RecommendationView> result = new ArrayList<>();
     if (gmcReferenceNumber == null) {
       throw new NullPointerException("gmcReferenceNumber is null");
-    } else {
+    } else if (gmcReferenceNumber.toLowerCase().equals("unknown")){
+      LOG.debug("CDC Skipped for doctor with GMC reference number: UNKNOWN");
+    }
+    else {
       try {
         result = recommendationElasticSearchRepository.findByGmcReferenceNumber(gmcReferenceNumber);
       } catch (Exception ex) {

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/RecommendationElasticSearchServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/RecommendationElasticSearchServiceTest.java
@@ -25,7 +25,9 @@ import static java.time.LocalDate.now;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -164,6 +166,14 @@ class RecommendationElasticSearchServiceTest {
         inputParam, dbcsParam);
 
     assertThat(results.size(), is(0));
+  }
+
+  @Test
+  void shouldNotUpdateUnknownDoctorsByGmcReferenceNumber() {
+    recommendationElasticSearchService.saveRecommendationViews(
+        RecommendationView.builder().id("123").gmcReferenceNumber("UNKNOWN").build());
+
+    verify(recommendationElasticSearchRepository, never()).findByGmcReferenceNumber(any());
   }
 
   private List<RecommendationView> generateListOfRecommendationViews() {


### PR DESCRIPTION
NO_TICKET: