### PR TITLE
build: use OIDC for AWS credentials

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,9 @@
 name: Deploy
 
+permissions:
+  id-token: write
+  contents: read
+
 on:
   push:
     branches:
@@ -25,9 +29,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_MAVEN_USERNAME }}
-          aws-secret-access-key: ${{ secrets.AWS_MAVEN_PASSWORD }}
           aws-region: eu-west-1
+          role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Add CodeArtifact env var
         run: echo "CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text)" >> $GITHUB_ENV
@@ -72,9 +75,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_MAVEN_USERNAME }}
-          aws-secret-access-key: ${{ secrets.AWS_MAVEN_PASSWORD }}
           aws-region: eu-west-1
+          role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Add CodeArtifact env var
         run: echo "CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text)" >> $GITHUB_ENV
@@ -107,9 +109,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Backup build artifacts
         run: |
@@ -135,9 +136,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Log in to Amazon ECR
         id: login-ecr
@@ -165,9 +165,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Log in to Amazon ECR
         id: login-ecr

--- a/.github/workflows/prod.deploy.yml
+++ b/.github/workflows/prod.deploy.yml
@@ -1,5 +1,9 @@
 name: Deploy to production
 
+permissions:
+  id-token: write
+  contents: read
+
 on: workflow_dispatch
 
 jobs:
@@ -14,9 +18,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Log in to Amazon ECR
         id: login-ecr


### PR DESCRIPTION
Remove the unused ecr and codeartifact user tokens and replace it with a role reference to the `github-actions-deployer-role` accessible using OIDC.

TIS21-4862