### PR TITLE
Feat/handle gmc number from reliable to unreliable

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/dto/MasterDoctorViewDto.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/dto/MasterDoctorViewDto.java
@@ -36,6 +36,7 @@ import lombok.NoArgsConstructor;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MasterDoctorViewDto {
 
+  String id;
   Long tcsPersonId;
   String gmcReferenceNumber;
   String doctorFirstName;

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/mapper/RecommendationViewMapper.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/mapper/RecommendationViewMapper.java
@@ -23,15 +23,15 @@ package uk.nhs.hee.tis.revalidation.mapper;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import uk.nhs.hee.tis.revalidation.dto.MasterDoctorViewDto;
 import uk.nhs.hee.tis.revalidation.dto.TraineeInfoDto;
+import uk.nhs.hee.tis.revalidation.entity.MasterDoctorView;
 import uk.nhs.hee.tis.revalidation.entity.RecommendationView;
 
 @Mapper(componentModel = "spring")
 public interface RecommendationViewMapper {
 
-  RecommendationView mapMasterDoctorViewDtoToRecommendationView(
-      MasterDoctorViewDto masterDoctorViewDto);
+  RecommendationView mapMasterDoctorViewToRecommendationView(
+      MasterDoctorView masterDoctorView);
 
   @Mapping(source = "tisStatus", target = "doctorStatus")
   @Mapping(source = "gmcStatus", target = "gmcOutcome")

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/mapper/RecommendationViewMapper.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/mapper/RecommendationViewMapper.java
@@ -25,7 +25,6 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import uk.nhs.hee.tis.revalidation.dto.MasterDoctorViewDto;
 import uk.nhs.hee.tis.revalidation.dto.TraineeInfoDto;
-import uk.nhs.hee.tis.revalidation.entity.MasterDoctorView;
 import uk.nhs.hee.tis.revalidation.entity.RecommendationView;
 
 @Mapper(componentModel = "spring")

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/mapper/RecommendationViewMapper.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/mapper/RecommendationViewMapper.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.revalidation.mapper;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import uk.nhs.hee.tis.revalidation.dto.MasterDoctorViewDto;
 import uk.nhs.hee.tis.revalidation.dto.TraineeInfoDto;
 import uk.nhs.hee.tis.revalidation.entity.MasterDoctorView;
 import uk.nhs.hee.tis.revalidation.entity.RecommendationView;
@@ -30,8 +31,8 @@ import uk.nhs.hee.tis.revalidation.entity.RecommendationView;
 @Mapper(componentModel = "spring")
 public interface RecommendationViewMapper {
 
-  RecommendationView mapMasterDoctorViewToRecommendationView(
-      MasterDoctorView masterDoctorView);
+  RecommendationView mapMasterDoctorViewDtoToRecommendationView(
+      MasterDoctorViewDto masterDoctorViewDto);
 
   @Mapping(source = "tisStatus", target = "doctorStatus")
   @Mapping(source = "gmcStatus", target = "gmcOutcome")

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/RabbitMessageListener.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/RabbitMessageListener.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.revalidation.dto.ConnectionMessageDto;
 import uk.nhs.hee.tis.revalidation.dto.DoctorsForDbDto;
+import uk.nhs.hee.tis.revalidation.dto.MasterDoctorViewDto;
 import uk.nhs.hee.tis.revalidation.dto.RecommendationStatusCheckDto;
 import uk.nhs.hee.tis.revalidation.entity.MasterDoctorView;
 import uk.nhs.hee.tis.revalidation.mapper.RecommendationViewMapper;
@@ -94,18 +95,18 @@ public class RabbitMessageListener {
   @RabbitListener(queues = "${app.rabbit.reval.queue.masterdoctorview.updated.recommendation}",
       ackMode = "NONE")
   public void receiveUpdateMessageFromMasterDoctorView(
-      final MasterDoctorView masterDoctorView) {
+      final MasterDoctorViewDto masterDoctorViewDto) {
 
-    if (masterDoctorView == null) {
+    if (masterDoctorViewDto == null) {
       throw new AmqpRejectAndDontRequeueException(
           "Received update message MasterDoctorView is null.");
     }
-    if (masterDoctorView.getId() == null) {
+    if (masterDoctorViewDto.getId() == null) {
       throw new AmqpRejectAndDontRequeueException(
           "Received update message MasterDoctorView with null id.");
     }
     recommendationElasticSearchService.saveRecommendationView(
-        recommendationViewMapper.mapMasterDoctorViewToRecommendationView(
-        masterDoctorView));
+        recommendationViewMapper.mapMasterDoctorViewDtoToRecommendationView(
+            masterDoctorViewDto));
   }
 }

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/repository/RecommendationElasticSearchRepository.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/repository/RecommendationElasticSearchRepository.java
@@ -65,4 +65,5 @@ public interface RecommendationElasticSearchRepository extends
 
   List<RecommendationView> findByGmcReferenceNumber(String gmcReferenceNumber);
 
+  List<RecommendationView> findByTcsPersonId(Long tcsPersonId);
 }

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/ElasticSearchIndexUpdateHelper.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/ElasticSearchIndexUpdateHelper.java
@@ -52,7 +52,7 @@ public class ElasticSearchIndexUpdateHelper {
    */
   public void updateElasticSearchIndex(final MasterDoctorViewDto masterDoctorViewDto) {
 
-    recommendationElasticSearchService.addRecommendationViews(
+    recommendationElasticSearchService.saveRecommendationView(
         buildRecommendationView(masterDoctorViewDto));
   }
 

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/mapper/RecommendationViewMapperTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/mapper/RecommendationViewMapperTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.nhs.hee.tis.revalidation.dto.MasterDoctorViewDto;
+import uk.nhs.hee.tis.revalidation.entity.MasterDoctorView;
 import uk.nhs.hee.tis.revalidation.entity.RecommendationView;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,7 +39,8 @@ class RecommendationViewMapperTest {
 
   @Test
   void shouldMapMasterDoctorViewDtoToRecommendationView() {
-    MasterDoctorViewDto dataToSave = new MasterDoctorViewDto();
+    MasterDoctorView dataToSave = new MasterDoctorView();
+    dataToSave.setId("1");
     dataToSave.setTcsPersonId(1000l);
     LocalDate submissionDate_new = LocalDate.now();
     dataToSave.setSubmissionDate(submissionDate_new);
@@ -48,15 +49,15 @@ class RecommendationViewMapperTest {
     dataToSave.setDesignatedBody("designatedBody_new");
     dataToSave.setUnderNotice("underNotice_new");
 
-    RecommendationView result = recommendationViewMapper.mapMasterDoctorViewDtoToRecommendationView(
+    RecommendationView result = recommendationViewMapper.mapMasterDoctorViewToRecommendationView(
         dataToSave);
 
+    assertThat(result.getId(), is("1"));
     assertThat(result.getTcsPersonId(), is(1000l));
     assertThat(result.getSubmissionDate(), is(submissionDate_new));
     assertThat(result.getProgrammeName(), is("programmeName_new"));
     assertThat(result.getMembershipType(), is("membershipType_new"));
     assertThat(result.getDesignatedBody(), is("designatedBody_new"));
     assertThat(result.getUnderNotice(), is("underNotice_new"));
-
   }
 }

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/mapper/RecommendationViewMapperTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/mapper/RecommendationViewMapperTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.nhs.hee.tis.revalidation.entity.MasterDoctorView;
+import uk.nhs.hee.tis.revalidation.dto.MasterDoctorViewDto;
 import uk.nhs.hee.tis.revalidation.entity.RecommendationView;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,9 +39,9 @@ class RecommendationViewMapperTest {
 
   @Test
   void shouldMapMasterDoctorViewDtoToRecommendationView() {
-    MasterDoctorView dataToSave = new MasterDoctorView();
+    MasterDoctorViewDto dataToSave = new MasterDoctorViewDto();
     dataToSave.setId("1");
-    dataToSave.setTcsPersonId(1000l);
+    dataToSave.setTcsPersonId(1000L);
     LocalDate submissionDate_new = LocalDate.now();
     dataToSave.setSubmissionDate(submissionDate_new);
     dataToSave.setProgrammeName("programmeName_new");
@@ -49,11 +49,11 @@ class RecommendationViewMapperTest {
     dataToSave.setDesignatedBody("designatedBody_new");
     dataToSave.setUnderNotice("underNotice_new");
 
-    RecommendationView result = recommendationViewMapper.mapMasterDoctorViewToRecommendationView(
+    RecommendationView result = recommendationViewMapper.mapMasterDoctorViewDtoToRecommendationView(
         dataToSave);
 
     assertThat(result.getId(), is("1"));
-    assertThat(result.getTcsPersonId(), is(1000l));
+    assertThat(result.getTcsPersonId(), is(1000L));
     assertThat(result.getSubmissionDate(), is(submissionDate_new));
     assertThat(result.getProgrammeName(), is("programmeName_new"));
     assertThat(result.getMembershipType(), is("membershipType_new"));

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/ElasticSearchIndexUpdateHelperTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/ElasticSearchIndexUpdateHelperTest.java
@@ -117,7 +117,7 @@ class ElasticSearchIndexUpdateHelperTest {
   @Test
   void shouldUpdateElasticSearchIndex() {
     elasticSearchIndexUpdateHelper.updateElasticSearchIndex(masterDoctorViewDto);
-    verify(recommendationElasticSearchService).addRecommendationViews(
+    verify(recommendationElasticSearchService).saveRecommendationView(
         elasticSearchIndexUpdateHelper.buildRecommendationView(masterDoctorViewDto));
   }
 }

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/RecommendationElasticSearchServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/RecommendationElasticSearchServiceTest.java
@@ -85,46 +85,6 @@ class RecommendationElasticSearchServiceTest {
   }
 
   @Test
-  void shouldAddRecommendationViews() {
-    recommendationElasticSearchService.addRecommendationViews(recommendationView);
-    verify(recommendationElasticSearchRepository, times(1)).save(recommendationView);
-  }
-
-  @Test
-  void shouldThrowExceptionWhenSavingNull() {
-    doThrow(new NullPointerException()).when(recommendationElasticSearchRepository).save(null);
-    assertThrows(Exception.class, () -> {
-      recommendationElasticSearchService.addRecommendationViews(null);
-    });
-  }
-
-  @Test
-  void shouldSaveRecommendationViewsWhenTheRecordIsAlreadyThereInTheESRepository() {
-    when(recommendationElasticSearchRepository.findByGmcReferenceNumber(gmcRef1)).thenReturn(
-        recommendationViews);
-    recommendationElasticSearchService.saveRecommendationViews(recommendationView);
-    verify(recommendationElasticSearchRepository, times(1)).save(recommendationView);
-  }
-
-  @Test
-  void shouldSaveRecommendationViewsWhenTheRecordIsNotThereInTheESRepository() {
-    recommendationElasticSearchService.saveRecommendationViews(recommendationView);
-    verify(recommendationElasticSearchRepository, times(1)).save(recommendationView);
-  }
-
-  @Test
-  void shouldThrowExceptionIfGmcReferenceNumberNull() {
-    recommendationView = RecommendationView.builder().id("1a2a").tcsPersonId((long) 111)
-        .gmcReferenceNumber(null).doctorFirstName(firstName1).doctorLastName(lastName1)
-        .submissionDate(submissionDate1).programmeName(programmeName1)
-        .designatedBody(designatedBody1).admin(admin).underNotice(underNotice).build();
-
-    assertThrows(Exception.class, () -> {
-      recommendationElasticSearchService.saveRecommendationViews(recommendationView);
-    });
-  }
-
-  @Test
   void shouldFormatDesignatedBodyCodesForElasticsearchQuery() {
     final String dbc1 = "1-AIIDHJ";
     final String dbc2 = "AIIDMQ";


### PR DESCRIPTION
Recommendationindex is reindexed from masterdoctorindex, and every time a masterdoctor view is updated, the corresponding recommendation view is updated to same data too.

Besides, I have checked Integration service and found there're more than one producers of messages of queue: `reval.queue.masterdoctorview.updated.recommendation` and they are: CdcTraineeUpdateService, CdcRecommendationService and CdcDoctorService. All of them save changes in Masterdoctorindex first, then send saved view to the queue, so the messages should contain ES document id.

depends on https://github.com/Health-Education-England/tis-revalidation-integration/pull/443