### PR TITLE
Feat/add gmc updated date time for doctor

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/dto/DoctorsForDbDto.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/dto/DoctorsForDbDto.java
@@ -44,4 +44,5 @@ public class DoctorsForDbDto {
   private String underNotice;
   private String sanction;
   private String designatedBodyCode;
+  private String gmcLastUpdatedDateTime;
 }

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/dto/DoctorsForDbDto.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/dto/DoctorsForDbDto.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.revalidation.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.annotations.ApiModel;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -44,5 +45,5 @@ public class DoctorsForDbDto {
   private String underNotice;
   private String sanction;
   private String designatedBodyCode;
-  private String gmcLastUpdatedDateTime;
+  private LocalDateTime gmcLastUpdatedDateTime;
 }

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/entity/DoctorsForDB.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/entity/DoctorsForDB.java
@@ -21,25 +21,20 @@
 
 package uk.nhs.hee.tis.revalidation.entity;
 
-
-import static java.time.LocalDate.now;
-import static uk.nhs.hee.tis.revalidation.entity.RecommendationStatus.NOT_STARTED;
-import static uk.nhs.hee.tis.revalidation.util.DateUtil.convertGmcDateToLocalDate;
-
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import io.swagger.annotations.ApiModel;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
-import org.springframework.lang.Nullable;
-import uk.nhs.hee.tis.revalidation.dto.DoctorsForDbDto;
 
 @Data
 @AllArgsConstructor
@@ -62,26 +57,12 @@ public class DoctorsForDB {
   private UnderNotice underNotice;
   private String sanction;
   private RecommendationStatus doctorStatus;
+  @LastModifiedDate
   @JsonDeserialize(using = LocalDateDeserializer.class)
   @JsonSerialize(using = LocalDateSerializer.class)
   private LocalDate lastUpdatedDate;
+  private LocalDateTime gmcLastUpdatedDateTime;
   private String designatedBodyCode;
   private String admin;
   private Boolean existsInGmc = true;
-
-  public static final  DoctorsForDB convert(final DoctorsForDbDto doctorsForDBDTO) {
-    return DoctorsForDB.builder()
-        .gmcReferenceNumber(doctorsForDBDTO.getGmcReferenceNumber())
-        .doctorFirstName(doctorsForDBDTO.getDoctorFirstName())
-        .doctorLastName(doctorsForDBDTO.getDoctorLastName())
-        .submissionDate(convertGmcDateToLocalDate(doctorsForDBDTO.getSubmissionDate()))
-        .dateAdded(convertGmcDateToLocalDate(doctorsForDBDTO.getDateAdded()))
-        .underNotice(UnderNotice.fromString(doctorsForDBDTO.getUnderNotice()))
-        .sanction(doctorsForDBDTO.getSanction())
-        .doctorStatus(NOT_STARTED)
-        .designatedBodyCode(doctorsForDBDTO.getDesignatedBodyCode())
-        .lastUpdatedDate(now())
-        .existsInGmc(true)
-        .build();
-  }
 }

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/mapper/DoctorsForDbMapper.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/mapper/DoctorsForDbMapper.java
@@ -20,10 +20,12 @@
  */
 package uk.nhs.hee.tis.revalidation.mapper;
 
+import java.time.LocalDateTime;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.springframework.util.StringUtils;
+import uk.nhs.hee.tis.revalidation.dto.DoctorsForDbDto;
 import uk.nhs.hee.tis.revalidation.dto.TraineeInfoDto;
 import uk.nhs.hee.tis.revalidation.entity.DoctorsForDB;
 
@@ -37,5 +39,28 @@ public interface DoctorsForDbMapper {
   @Named("desgnatedBodyToConnectionStatus")
   default String designatedBodyToConnectionStatus(String designatedBody) {
     return StringUtils.hasLength(designatedBody) ? "Yes" : "No";
+  }
+
+  @Mapping(target = "submissionDate", expression = "java("
+      + "uk.nhs.hee.tis.revalidation.util.DateUtil"
+      + ".convertGmcDateToLocalDate(dto.getSubmissionDate()))")
+  @Mapping(target = "dateAdded", expression = "java("
+      + "uk.nhs.hee.tis.revalidation.util.DateUtil.convertGmcDateToLocalDate(dto.getDateAdded()))")
+  @Mapping(target = "underNotice", expression = "java("
+      + "uk.nhs.hee.tis.revalidation.entity.UnderNotice.fromString(dto.getUnderNotice()))")
+  @Mapping(target = "lastUpdatedDate", expression = "java(java.time.LocalDate.now())")
+  @Mapping(target = "gmcLastUpdatedDateTime", source = "gmcLastUpdatedDateTime",
+      qualifiedByName = "localDateTimeFromString")
+  @Mapping(target = "existsInGmc", constant = "true")
+  @Mapping(target = "doctorStatus", constant = "NOT_STARTED")
+  DoctorsForDB toEntity(DoctorsForDbDto dto);
+
+  @Named("localDateTimeFromString")
+  default LocalDateTime localDateTimeFromString(String gmcLastUpdatedDateTime) {
+    if (StringUtils.hasLength(gmcLastUpdatedDateTime)) {
+      return LocalDateTime.parse(gmcLastUpdatedDateTime);
+    } else {
+      return null;
+    }
   }
 }

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/mapper/DoctorsForDbMapper.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/mapper/DoctorsForDbMapper.java
@@ -20,6 +20,7 @@
  */
 package uk.nhs.hee.tis.revalidation.mapper;
 
+import java.time.LocalDate;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -27,6 +28,7 @@ import org.springframework.util.StringUtils;
 import uk.nhs.hee.tis.revalidation.dto.DoctorsForDbDto;
 import uk.nhs.hee.tis.revalidation.dto.TraineeInfoDto;
 import uk.nhs.hee.tis.revalidation.entity.DoctorsForDB;
+import uk.nhs.hee.tis.revalidation.entity.RecommendationStatus;
 
 @Mapper(componentModel = "spring")
 public interface DoctorsForDbMapper {
@@ -40,15 +42,10 @@ public interface DoctorsForDbMapper {
     return StringUtils.hasLength(designatedBody) ? "Yes" : "No";
   }
 
-  @Mapping(target = "submissionDate", expression = "java("
-      + "uk.nhs.hee.tis.revalidation.util.DateUtil"
-      + ".convertGmcDateToLocalDate(dto.getSubmissionDate()))")
-  @Mapping(target = "dateAdded", expression = "java("
-      + "uk.nhs.hee.tis.revalidation.util.DateUtil.convertGmcDateToLocalDate(dto.getDateAdded()))")
   @Mapping(target = "underNotice", expression = "java("
       + "uk.nhs.hee.tis.revalidation.entity.UnderNotice.fromString(dto.getUnderNotice()))")
-  @Mapping(target = "lastUpdatedDate", expression = "java(java.time.LocalDate.now())")
-  @Mapping(target = "existsInGmc", constant = "true")
-  @Mapping(target = "doctorStatus", constant = "NOT_STARTED")
-  DoctorsForDB toEntity(DoctorsForDbDto dto);
+  @Mapping(target = "dateAdded", dateFormat = "dd/MM/yyyy")
+  @Mapping(target = "submissionDate", dateFormat = "dd/MM/yyyy")
+  DoctorsForDB toEntity(DoctorsForDbDto dto, LocalDate lastUpdatedDate, boolean existsInGmc,
+      RecommendationStatus doctorStatus);
 }

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/mapper/DoctorsForDbMapper.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/mapper/DoctorsForDbMapper.java
@@ -20,7 +20,6 @@
  */
 package uk.nhs.hee.tis.revalidation.mapper;
 
-import java.time.LocalDateTime;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -49,18 +48,7 @@ public interface DoctorsForDbMapper {
   @Mapping(target = "underNotice", expression = "java("
       + "uk.nhs.hee.tis.revalidation.entity.UnderNotice.fromString(dto.getUnderNotice()))")
   @Mapping(target = "lastUpdatedDate", expression = "java(java.time.LocalDate.now())")
-  @Mapping(target = "gmcLastUpdatedDateTime", source = "gmcLastUpdatedDateTime",
-      qualifiedByName = "localDateTimeFromString")
   @Mapping(target = "existsInGmc", constant = "true")
   @Mapping(target = "doctorStatus", constant = "NOT_STARTED")
   DoctorsForDB toEntity(DoctorsForDbDto dto);
-
-  @Named("localDateTimeFromString")
-  default LocalDateTime localDateTimeFromString(String gmcLastUpdatedDateTime) {
-    if (StringUtils.hasLength(gmcLastUpdatedDateTime)) {
-      return LocalDateTime.parse(gmcLastUpdatedDateTime);
-    } else {
-      return null;
-    }
-  }
 }

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
@@ -101,7 +101,7 @@ public class DoctorsForDBService {
   }
 
   public void updateTrainee(final DoctorsForDbDto gmcDoctor) {
-    final var doctorsForDB = DoctorsForDB.convert(gmcDoctor);
+    final var doctorsForDB = doctorsForDbMapper.toEntity(gmcDoctor);
     final var doctor = doctorsRepository.findById(gmcDoctor.getGmcReferenceNumber());
     if (doctor.isPresent()) {
       doctorsForDB.setAdmin(doctor.get().getAdmin());

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
@@ -100,7 +100,13 @@ public class DoctorsForDBService {
         .totalResults(paginatedDoctors.getTotalElements()).build();
   }
 
+  /**
+   * During nightly sync job, update DoctorsForDB data after we get data from GMC.
+   *
+   * @param gmcDoctor doctor dto from GMC
+   */
   public void updateTrainee(final DoctorsForDbDto gmcDoctor) {
+    // Set default lastUpdatedDate, existsInGmc and doctorStatus when mapping dto to entity.
     final var doctorsForDB = doctorsForDbMapper.toEntity(gmcDoctor, now(), true,
         RecommendationStatus.NOT_STARTED);
     final var doctor = doctorsRepository.findById(gmcDoctor.getGmcReferenceNumber());

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
@@ -101,7 +101,8 @@ public class DoctorsForDBService {
   }
 
   public void updateTrainee(final DoctorsForDbDto gmcDoctor) {
-    final var doctorsForDB = doctorsForDbMapper.toEntity(gmcDoctor);
+    final var doctorsForDB = doctorsForDbMapper.toEntity(gmcDoctor, now(), true,
+        RecommendationStatus.NOT_STARTED);
     final var doctor = doctorsRepository.findById(gmcDoctor.getGmcReferenceNumber());
     if (doctor.isPresent()) {
       doctorsForDB.setAdmin(doctor.get().getAdmin());

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/util/DateUtil.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/util/DateUtil.java
@@ -66,14 +66,4 @@ public class DateUtil {
 
     return null;
   }
-
-  public static LocalDate convertGmcDateToLocalDate(final String date) {
-    log.debug("Format date to GMC format: {}", date);
-    if (StringUtils.hasLength(date)) {
-      return parse(date, GMC_DATE_FORMATTER);
-    }
-
-    return null;
-  }
-
 }

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/JsonSerializationTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/JsonSerializationTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.core.Is.is;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import uk.nhs.hee.tis.revalidation.dto.DoctorsForDbDto;
 
@@ -45,12 +46,17 @@ class JsonSerializationTest {
         .sanction("sanction")
         .underNotice("under notice")
         .dateAdded("04/07/2017")
-        .submissionDate("04/07/2017").build();
+        .submissionDate("04/07/2017")
+        .gmcLastUpdatedDateTime(LocalDateTime.of(2023, 11, 14,
+            9, 55, 20, 123456)).build();
 
     final var json = mapper.writeValueAsString(doctor);
 
     assertThat(json,
-        is("{\"gmcReferenceNumber\":\"gmtRef\",\"doctorFirstName\":\"first\",\"doctorLastName\":\"last\",\"submissionDate\":\"04/07/2017\",\"dateAdded\":\"04/07/2017\",\"underNotice\":\"under notice\",\"sanction\":\"sanction\",\"designatedBodyCode\":null}"));
+        is("{\"gmcReferenceNumber\":\"gmtRef\",\"doctorFirstName\":\"first\","
+            + "\"doctorLastName\":\"last\",\"submissionDate\":\"04/07/2017\","
+            + "\"dateAdded\":\"04/07/2017\",\"underNotice\":\"under notice\","
+            + "\"sanction\":\"sanction\",\"designatedBodyCode\":null,"
+            + "\"gmcLastUpdatedDateTime\":\"2023-11-14T09:55:20.000123456\"}"));
   }
-
 }

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/mapper/DoctorForDbMapperTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/mapper/DoctorForDbMapperTest.java
@@ -20,7 +20,6 @@
  */
 package uk.nhs.hee.tis.revalidation.mapper;
 
-import static java.time.LocalDateTime.now;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -28,7 +27,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.javafaker.Faker;
@@ -125,18 +123,6 @@ class DoctorForDbMapperTest {
     assertThat(testObj.designatedBodyToConnectionStatus("Oooh"), is(CONNECTION_STATUS_YES));
   }
 
-  @ParameterizedTest
-  @NullAndEmptySource
-  void shouldReturnNullWhenLocalDateTimeFromEmptyString(String dateTime) {
-    assertNull(testObj.localDateTimeFromString(dateTime));
-  }
-
-  @Test
-  void shouldReturnLocalDateTimeFromString() {
-    LocalDateTime now = now();
-    assertEquals(now, testObj.localDateTimeFromString(now.toString()));
-  }
-
   @Test
   void shouldMapDoctorsForDbDtoToEntity() {
     DoctorsForDbDto doctorsForDbDto = DoctorsForDbDto.builder()
@@ -147,7 +133,7 @@ class DoctorForDbMapperTest {
         .underNotice(underNotice.toString())
         .dateAdded(dateAdded.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")))
         .submissionDate(submissionDate.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")))
-        .gmcLastUpdatedDateTime(gmcLastUpdatedDateTime.toString())
+        .gmcLastUpdatedDateTime(gmcLastUpdatedDateTime)
         .designatedBodyCode(dbc)
         .build();
 

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/mapper/DoctorForDbMapperTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/mapper/DoctorForDbMapperTest.java
@@ -138,17 +138,17 @@ class DoctorForDbMapperTest {
         .build();
 
     DoctorsForDB doctorsForDb = testObj.toEntity(doctorsForDbDto);
-    assertEquals(doctorsForDb.getGmcReferenceNumber(), gmcNumber);
-    assertEquals(doctorsForDb.getDoctorFirstName(), firstName);
-    assertEquals(doctorsForDb.getDoctorLastName(), lastName);
-    assertEquals(doctorsForDb.getSanction(), sanction);
-    assertEquals(doctorsForDb.getDesignatedBodyCode(), dbc);
-    assertEquals(doctorsForDb.getSubmissionDate(), submissionDate);
-    assertEquals(doctorsForDb.getDateAdded(), dateAdded);
-    assertEquals(doctorsForDb.getUnderNotice(), underNotice);
-    assertEquals(doctorsForDb.getGmcLastUpdatedDateTime(), gmcLastUpdatedDateTime);
+    assertEquals(gmcNumber, doctorsForDb.getGmcReferenceNumber());
+    assertEquals(firstName, doctorsForDb.getDoctorFirstName());
+    assertEquals(lastName, doctorsForDb.getDoctorLastName());
+    assertEquals(sanction, doctorsForDb.getSanction());
+    assertEquals(dbc, doctorsForDb.getDesignatedBodyCode());
+    assertEquals(submissionDate, doctorsForDb.getSubmissionDate());
+    assertEquals(dateAdded, doctorsForDb.getDateAdded());
+    assertEquals(underNotice, doctorsForDb.getUnderNotice());
+    assertEquals(gmcLastUpdatedDateTime, doctorsForDb.getGmcLastUpdatedDateTime());
     assertTrue(doctorsForDb.getExistsInGmc());
-    assertEquals(doctorsForDb.getDoctorStatus(), RecommendationStatus.NOT_STARTED);
+    assertEquals(RecommendationStatus.NOT_STARTED, doctorsForDb.getDoctorStatus());
     assertNotNull(doctorsForDb.getLastUpdatedDate());
   }
 }

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/mapper/DoctorsForDbMapperTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/mapper/DoctorsForDbMapperTest.java
@@ -27,7 +27,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.javafaker.Faker;

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/mapper/DoctorsForDbMapperTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/mapper/DoctorsForDbMapperTest.java
@@ -20,6 +20,7 @@
  */
 package uk.nhs.hee.tis.revalidation.mapper;
 
+import static java.time.LocalDate.now;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -43,7 +44,7 @@ import uk.nhs.hee.tis.revalidation.entity.DoctorsForDB;
 import uk.nhs.hee.tis.revalidation.entity.RecommendationStatus;
 import uk.nhs.hee.tis.revalidation.entity.UnderNotice;
 
-class DoctorForDbMapperTest {
+class DoctorsForDbMapperTest {
 
   public static final String CONNECTION_STATUS_YES = "Yes";
   private final Faker faker = new Faker();
@@ -51,8 +52,8 @@ class DoctorForDbMapperTest {
   private final String gmcNumber = faker.number().digits(7);
   private final String firstName = faker.name().firstName();
   private final String lastName = faker.name().lastName();
-  private final LocalDate submissionDate = LocalDate.now().minusDays(1);
-  private final LocalDate dateAdded = LocalDate.now().minusMonths(1);
+  private final LocalDate submissionDate = now().minusDays(1);
+  private final LocalDate dateAdded = now().minusMonths(1);
   private final UnderNotice underNotice = UnderNotice.NO;
   private final String sanction = faker.lorem().characters(2);
   private final LocalDateTime gmcLastUpdatedDateTime = LocalDateTime.now();
@@ -137,7 +138,9 @@ class DoctorForDbMapperTest {
         .designatedBodyCode(dbc)
         .build();
 
-    DoctorsForDB doctorsForDb = testObj.toEntity(doctorsForDbDto);
+    LocalDate now = LocalDate.now();
+    DoctorsForDB doctorsForDb = testObj.toEntity(doctorsForDbDto, now, true,
+        RecommendationStatus.NOT_STARTED);
     assertEquals(gmcNumber, doctorsForDb.getGmcReferenceNumber());
     assertEquals(firstName, doctorsForDb.getDoctorFirstName());
     assertEquals(lastName, doctorsForDb.getDoctorLastName());
@@ -149,6 +152,6 @@ class DoctorForDbMapperTest {
     assertEquals(gmcLastUpdatedDateTime, doctorsForDb.getGmcLastUpdatedDateTime());
     assertTrue(doctorsForDb.getExistsInGmc());
     assertEquals(RecommendationStatus.NOT_STARTED, doctorsForDb.getDoctorStatus());
-    assertNotNull(doctorsForDb.getLastUpdatedDate());
+    assertEquals(now, doctorsForDb.getLastUpdatedDate());
   }
 }

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBServiceTest.java
@@ -819,7 +819,7 @@ class DoctorsForDBServiceTest {
 
     docDto1 = new DoctorsForDbDto();
     docDto1.setGmcReferenceNumber(gmcRef1);
-    docDto1.setGmcLastUpdatedDateTime(gmcLastUpdatedDateTime.toString());
+    docDto1.setGmcLastUpdatedDateTime(gmcLastUpdatedDateTime);
     docDto1.setUnderNotice(YES.value());
 
     docDto2 = new DoctorsForDbDto();

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/util/DateUtilTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/util/DateUtilTest.java
@@ -21,14 +21,12 @@
 
 package uk.nhs.hee.tis.revalidation.util;
 
-import static java.time.LocalDate.of;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static uk.nhs.hee.tis.revalidation.util.DateUtil.convertDateInGmcFormat;
-import static uk.nhs.hee.tis.revalidation.util.DateUtil.convertGmcDateToLocalDate;
 import static uk.nhs.hee.tis.revalidation.util.DateUtil.formatDate;
 import static uk.nhs.hee.tis.revalidation.util.DateUtil.formatDateTime;
 
@@ -90,22 +88,4 @@ class DateUtilTest {
     assertNotNull(gmcDate);
     assertThat(gmcDate, is("19/07/2017"));
   }
-
-  @Test
-  void shouldFormatGmcFormatStringDateToLocalDate() {
-    final var dateToFormat = "04/07/2017";
-    final var localDate = of(2017, 07, 04);
-
-    final var gmcDate = convertGmcDateToLocalDate(dateToFormat);
-    assertNotNull(gmcDate);
-    assertThat(gmcDate, is(localDate));
-  }
-
-  @Test
-  void shouldReturnNullWhenDateIsEmptyString() {
-    final var dateToFormat = "";
-    final var gmcDate = convertGmcDateToLocalDate(dateToFormat);
-    assertNull(gmcDate);
-  }
-
 }

--- a/integration-tests/src/test/java/uk/nhs/hee/tis/revalidation/it/BaseIT.java
+++ b/integration-tests/src/test/java/uk/nhs/hee/tis/revalidation/it/BaseIT.java
@@ -158,15 +158,15 @@ public class BaseIT {
     admin = faker.internet().emailAddress();
 
     doc1 = new DoctorsForDB(gmcRef1, fName1, lName1, subDate1, addedDate1, un1, sanction1, status1,
-        now(), desBody1, admin, true);
+        now(), null, desBody1, admin, true);
     doc2 = new DoctorsForDB(gmcRef2, fName2, lName2, subDate2, addedDate2, un2, sanction2, status2,
-        now(), desBody2, admin, true);
+        now(), null, desBody2, admin, true);
     doc3 = new DoctorsForDB(gmcRef3, fName3, lName3, subDate3, addedDate3, un3, sanction3, status3,
-        now(), desBody3, admin, true);
+        now(), null, desBody3, admin, true);
     doc4 = new DoctorsForDB(gmcRef4, fName4, lName4, subDate4, addedDate4, un4, sanction4, status4,
-        now(), desBody4, admin, true);
+        now(), null, desBody4, admin, true);
     doc5 = new DoctorsForDB(gmcRef5, fName5, lName5, subDate5, addedDate5, un5, sanction5, status5,
-        now(), desBody5, admin, true);
+        now(), null, desBody5, admin, true);
 
     coreDTO1 = new TraineeCoreDto(gmcRef1, curriculumEndDate1, memType1, progName1, grade1);
     coreDTO2 = new TraineeCoreDto(gmcRef2, curriculumEndDate2, memType2, progName2, grade2);


### PR DESCRIPTION
After receiving gmc nightly sync doctor messages from gmc-client, update the entity and save it to DB. During this process, add the field `gmcUpdatedDateTime` to dto and entity.

TIS21-5224