### PR TITLE
feat:enable Mongo Auditing

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/RevalidationApplication.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/RevalidationApplication.java
@@ -31,12 +31,14 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.ws.client.core.WebServiceTemplate;
 
 @EnableMongock
 @SpringBootApplication
+@EnableMongoAuditing
 public class RevalidationApplication {
 
   public static void main(String[] args) {

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/RevalidationApplication.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/RevalidationApplication.java
@@ -31,14 +31,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
-import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.ws.client.core.WebServiceTemplate;
 
 @EnableMongock
 @SpringBootApplication
-@EnableMongoAuditing
 public class RevalidationApplication {
 
   public static void main(String[] args) {

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/config/MongoDbConfig.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/config/MongoDbConfig.java
@@ -1,0 +1,10 @@
+package uk.nhs.hee.tis.revalidation.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+
+@Configuration
+@EnableMongoAuditing
+public class MongoDbConfig {
+
+}

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/mapper/DoctorsForDbMapper.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/mapper/DoctorsForDbMapper.java
@@ -46,6 +46,7 @@ public interface DoctorsForDbMapper {
       + "uk.nhs.hee.tis.revalidation.entity.UnderNotice.fromString(dto.getUnderNotice()))")
   @Mapping(target = "dateAdded", dateFormat = "dd/MM/yyyy")
   @Mapping(target = "submissionDate", dateFormat = "dd/MM/yyyy")
-  DoctorsForDB toEntity(DoctorsForDbDto dto, LocalDate lastUpdatedDate, boolean existsInGmc,
+  @Mapping(target = "lastUpdatedDate", ignore = true)
+  DoctorsForDB toEntity(DoctorsForDbDto dto, boolean existsInGmc,
       RecommendationStatus doctorStatus);
 }

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/mapper/DoctorsForDbMapper.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/mapper/DoctorsForDbMapper.java
@@ -20,7 +20,6 @@
  */
 package uk.nhs.hee.tis.revalidation.mapper;
 
-import java.time.LocalDate;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
@@ -107,7 +107,7 @@ public class DoctorsForDBService {
    */
   public void updateTrainee(final DoctorsForDbDto gmcDoctor) {
     // Set default lastUpdatedDate, existsInGmc and doctorStatus when mapping dto to entity.
-    final var doctorsForDB = doctorsForDbMapper.toEntity(gmcDoctor, now(), true,
+    final var doctorsForDB = doctorsForDbMapper.toEntity(gmcDoctor, true,
         RecommendationStatus.NOT_STARTED);
     final var doctor = doctorsRepository.findById(gmcDoctor.getGmcReferenceNumber());
     if (doctor.isPresent()) {
@@ -130,7 +130,6 @@ public class DoctorsForDBService {
       if (doctor.isPresent()) {
         final var doctorsForDB = doctor.get();
         doctorsForDB.setAdmin(traineeAdmin.getAdmin());
-        doctorsForDB.setLastUpdatedDate(now());
         doctorsRepository.save(doctorsForDB);
       }
     });
@@ -157,7 +156,6 @@ public class DoctorsForDBService {
       }
       doctorsForDb.setSubmissionDate(message.getSubmissionDate());
       doctorsForDb.setGmcLastUpdatedDateTime(message.getGmcLastUpdatedDateTime());
-      doctorsForDb.setLastUpdatedDate(LocalDate.now());
       doctorsRepository.save(doctorsForDb);
     } else {
       log.info("No doctor found to update designated body code");

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceImpl.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/RecommendationServiceImpl.java
@@ -211,7 +211,6 @@ public class RecommendationServiceImpl implements RecommendationService {
     }
 
     Recommendation savedRecommendation = recommendationRepository.save(recommendation);
-    doctor.setLastUpdatedDate(now());
     doctor.setDoctorStatus(
         getRecommendationStatusForTrainee(recordDTO.getGmcNumber())
     );
@@ -265,7 +264,6 @@ public class RecommendationServiceImpl implements RecommendationService {
         recommendation.setActualSubmissionDate(now());
         recommendation.setGmcRevalidationId(tryRecommendationResponseCT.getRecommendationID());
         recommendationRepository.save(recommendation);
-        doctor.setLastUpdatedDate(now());
         doctor.setDoctorStatus(getRecommendationStatusForTrainee(gmcNumber)
         );
         doctorsForDBRepository.save(doctor);

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/mapper/DoctorsForDbMapperTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/mapper/DoctorsForDbMapperTest.java
@@ -138,7 +138,7 @@ class DoctorsForDbMapperTest {
         .build();
 
     LocalDate now = LocalDate.now();
-    DoctorsForDB doctorsForDb = testObj.toEntity(doctorsForDbDto, now, true,
+    DoctorsForDB doctorsForDb = testObj.toEntity(doctorsForDbDto, true,
         RecommendationStatus.NOT_STARTED);
     assertEquals(gmcNumber, doctorsForDb.getGmcReferenceNumber());
     assertEquals(firstName, doctorsForDb.getDoctorFirstName());
@@ -151,6 +151,5 @@ class DoctorsForDbMapperTest {
     assertEquals(gmcLastUpdatedDateTime, doctorsForDb.getGmcLastUpdatedDateTime());
     assertTrue(doctorsForDb.getExistsInGmc());
     assertEquals(RecommendationStatus.NOT_STARTED, doctorsForDb.getDoctorStatus());
-    assertEquals(now, doctorsForDb.getLastUpdatedDate());
   }
 }

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBServiceTest.java
@@ -538,7 +538,6 @@ class DoctorsForDBServiceTest {
 
     verify(repository).save(doctorCaptor.capture());
     DoctorsForDB doctor = doctorCaptor.getValue();
-    assertThat(doctor.getLastUpdatedDate(), is(LocalDate.now()));
     assertThat(doctor.getDesignatedBodyCode(), is(designatedBody2));
     assertThat(doctor.getExistsInGmc(), is(true));
     assertThat(doctor.getSubmissionDate(), is(subDate2));
@@ -726,7 +725,7 @@ class DoctorsForDBServiceTest {
     outcome1 = String.valueOf(RecommendationGmcOutcome.UNDER_REVIEW);
 
     doc1 = new DoctorsForDB(gmcRef1, fname1, lname1, subDate1, addedDate1, un1, sanction1, status1,
-        now().minusDays(1), LocalDateTime.now().minusDays(1), designatedBody1, admin1, true);
+        now(), LocalDateTime.now().minusDays(1), designatedBody1, admin1, true);
     doc2 = new DoctorsForDB(gmcRef2, fname2, lname2, subDate2, addedDate2, un2, sanction2, status2,
         now(), null, designatedBody2, admin2, true);
     doc3 = new DoctorsForDB(gmcRef3, fname3, lname3, subDate3, addedDate3, un3, sanction3, status3,


### PR DESCRIPTION
1. This config will enable the annotation @LastModifiedDate in DoctorsForDB entity, so anywhere when `doctorsForDBRepository.save()` is called, `lastUpdatedDate` will be updated.

2. I've found for Recommendation Status Check job, the update of doctorStatus in DoctorsForDB collection doesn't update the field `lastUpdateDate`, see code [here](https://github.com/Health-Education-England/tis-revalidation-recommendation/blob/3839a2e04de2c367bee64aab94f217ab0ebb8409/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/RecommendationStatusCheckUpdatedMessageHandler.java#L79), but this PR will update `lastUpdatedDate`.

3. I tried adding the annotation in main class first, but found it caused all WebMvcTest failing because of no Mongo Auditing related beans were found. So I created another empty config class to do the annotation. TBH, This new annotation can be configured after any `@Configuration` annoation.

4. Tested locally.

TIS21-5224