### PR TITLE
chore: use 512 (0.5 CPUs)

### DIFF
--- a/.aws/task-definition-prod.json
+++ b/.aws/task-definition-prod.json
@@ -113,6 +113,6 @@
     "FARGATE"
   ],
   "networkMode": "awsvpc",
-  "cpu": "256",
+  "cpu": "512",
   "memory": "1024"
 }


### PR DESCRIPTION
Tasks are failing to become healthy in production. 512 is the max without increasing memory as well

TIS21-5152: Process Change Stream messages quicker