### PR TITLE
feat: use alias instead of dedicated index for recommendations elasti…

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/entity/RecommendationView.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/entity/RecommendationView.java
@@ -41,7 +41,7 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 @AllArgsConstructor
 @Builder
 @Data
-@Document(indexName = "recommendationindex")
+@Document(indexName = "recommendations")
 public class RecommendationView {
 
   @Id


### PR DESCRIPTION
…csearch

TIS21-5482: Use Alias to MasterDoctorIndex instead of separate RecommendationIndex