### PR TITLE
chore: use 512 (0.5 CPUs)

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -117,6 +117,6 @@
     "FARGATE"
   ],
   "networkMode": "awsvpc",
-  "cpu": "256",
+  "cpu": "512",
   "memory": "1024"
 }


### PR DESCRIPTION
This updates preprod to match production.
Tasks were not reaching healthy in production.
 It is sometimes an issue on preprod too.
512 is the max without increasing memory as well.

TIS21-5152: Process Change Stream messages quicker