### PR TITLE
refactor: use standardised doctor received queue

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/RabbitMessageListener.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/messages/RabbitMessageListener.java
@@ -30,7 +30,6 @@ import uk.nhs.hee.tis.revalidation.dto.ConnectionMessageDto;
 import uk.nhs.hee.tis.revalidation.dto.DoctorsForDbDto;
 import uk.nhs.hee.tis.revalidation.dto.MasterDoctorViewDto;
 import uk.nhs.hee.tis.revalidation.dto.RecommendationStatusCheckDto;
-import uk.nhs.hee.tis.revalidation.entity.MasterDoctorView;
 import uk.nhs.hee.tis.revalidation.mapper.RecommendationViewMapper;
 import uk.nhs.hee.tis.revalidation.service.DoctorsForDBService;
 import uk.nhs.hee.tis.revalidation.service.RecommendationElasticSearchService;
@@ -51,7 +50,7 @@ public class RabbitMessageListener {
   @Autowired
   private RecommendationElasticSearchService recommendationElasticSearchService;
 
-  @RabbitListener(queues = "${app.rabbit.queue}")
+  @RabbitListener(queues = "${app.rabbit.reval.queue.doctorfordb.received.recommendation}")
   public void receivedMessage(final DoctorsForDbDto gmcDoctor) {
     try {
       log.debug("DoctorsForDbDto message received from rabbit: {}", gmcDoctor);

--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -61,20 +61,15 @@ app:
     sort.order: ${SORT_ORDER:asc,desc}
 
   rabbit:
-    exchange: ${EXCHANGE:reval.exchange.gmcsync}
-    queue: ${QUEUE:reval.queue.gmcsync.recommendation}
-    routingKey: ${ROUTING_KEY:reval.gmcsync}
     connection.queue: ${CONNECTION_QUEUE:reval.queue.connection.manualupdate.recommendation}
-    connection.routingKey: ${CONNECTION_ROUTING_KEY:reval.connection.manualupdate}
-    reval.exchange: ${REVAL_RABBIT_EXCHANGE:reval.exchange}
-    reval.queue.recommendation.syncstart: ${REVAL_RABBIT_RECOMMENDATION_SYNC_START_QUEUE:reval.queue.recommendation.syncstart}
-    reval.routingKey.recommendation.syncstart: ${REVAL_RABBIT_RECOMMENDATION_SYNCSTART_ROUTING_KEY:reval.recommendation.syncstart}
-    reval.queue.recommendationStatusCheck.updated: ${REVAL_RABBIT_RECOMMENDATION_STATUS_CHECK_UPDATED_QUEUE:reval.queue.recommendationstatuscheck.updated.recommendation}
-    reval.routingKey.recommendationstatuscheck.requested: ${REVAL_RABBIT_RECOMMENDATION_STATUS_CHECK_REQUESTED_ROUTING_KEY:reval.recommendationstatuscheck.requested}
-    reval.queue.gmcsync.requested.gmcclient: ${REVAL_RABBIT_GMCSYNC_REQUESTED_GMCCLIENT_QUEUE:reval.queue.gmcsync.requested.gmcclient}
-    reval.routingKey.gmcsync.requested.gmcclient: ${REVAL_RABBIT_GMCSYNC_REQUESTED_GMCCLIENT_ROUTING_KEY:reval.gmcsync.requested}
-    reval.queue.masterdoctorview.updated.recommendation: ${REVAL_RABBIT_UPDATE_RECOMMENDATION_INDEX_VIEW:reval.queue.masterdoctorview.updated.recommendation}
-    reval.routingKey.masterdoctorview.updated.recommendation: ${REVAL_RABBIT_UPDATE_RECOMMENDATION_INDEX_VIEW_ROUTING_KEY:reval.masterdoctorview.updated}
+    reval:
+      exchange: ${REVAL_RABBIT_EXCHANGE:reval.exchange}
+      queue.recommendation.syncstart: ${REVAL_RABBIT_RECOMMENDATION_SYNC_START_QUEUE:reval.queue.recommendation.syncstart}
+      queue.recommendationStatusCheck.updated: ${REVAL_RABBIT_RECOMMENDATION_STATUS_CHECK_UPDATED_QUEUE:reval.queue.recommendationstatuscheck.updated.recommendation}
+      routingKey.recommendationstatuscheck.requested: ${REVAL_RABBIT_RECOMMENDATION_STATUS_CHECK_REQUESTED_ROUTING_KEY:reval.recommendationstatuscheck.requested}
+      routingKey.gmcsync.requested.gmcclient: ${REVAL_RABBIT_GMCSYNC_REQUESTED_GMCCLIENT_ROUTING_KEY:reval.gmcsync.requested}
+      queue.doctorfordb.received.recommendation: ${REVAL_RABBIT_DOCTOR_DB_QUEUE:reval.queue.doctorfordb.received.recommendation}
+      queue.masterdoctorview.updated.recommendation: ${REVAL_RABBIT_UPDATE_RECOMMENDATION_INDEX_VIEW:reval.queue.masterdoctorview.updated.recommendation}
 
   gmc:
     url: ${GMC_CONNECT_URL:http://localhost:8090/GMCConnectMock2020/GMCWebServices}

--- a/integration-tests/src/test/resources/application-test.yml
+++ b/integration-tests/src/test/resources/application-test.yml
@@ -55,9 +55,15 @@ app:
     tcs.url: ${TCS_URL:http://localhost:8080/tcsmock/api/revalidation}
 
   rabbit:
-    exchange: ${EXCHANGE:reval.exchange.gmcsync}
-    queue: ${QUEUE:reval.queue.gmcsync.recommendation}
-    routingKey: ${ROUTING_KEY:reval.gmcsync}
+    connection.queue: ${CONNECTION_QUEUE:reval.queue.connection.manualupdate.recommendation}
+    reval:
+      exchange: ${REVAL_RABBIT_EXCHANGE:reval.exchange}
+      queue.recommendation.syncstart: ${REVAL_RABBIT_RECOMMENDATION_SYNC_START_QUEUE:reval.queue.recommendation.syncstart}
+      queue.recommendationStatusCheck.updated: ${REVAL_RABBIT_RECOMMENDATION_STATUS_CHECK_UPDATED_QUEUE:reval.queue.recommendationstatuscheck.updated.recommendation}
+      routingKey.recommendationstatuscheck.requested: ${REVAL_RABBIT_RECOMMENDATION_STATUS_CHECK_REQUESTED_ROUTING_KEY:reval.recommendationstatuscheck.requested}
+      routingKey.gmcsync.requested.gmcclient: ${REVAL_RABBIT_GMCSYNC_REQUESTED_GMCCLIENT_ROUTING_KEY:reval.gmcsync.requested}
+      queue.doctorfordb.received.recommendation: ${REVAL_RABBIT_DOCTOR_DB_QUEUE:reval.queue.doctorfordb.received.recommendation}
+      queue.masterdoctorview.updated.recommendation: ${REVAL_RABBIT_UPDATE_RECOMMENDATION_INDEX_VIEW:reval.queue.masterdoctorview.updated.recommendation}
 
   gmc:
     url: ${GMC_CONNECT_URL:http://localhost:8090/GMCConnectMock2020/GMCWebServices}


### PR DESCRIPTION
Depends on releasing https://github.com/Health-Education-England/TIS-RabbitMQ/pull/87.
That is the only reason the PR is draft

chore: remove unnecessary properties

This cleans up the config.
Where it is needed for tests it is included in those configs

TIS21-5226: Disconnect doctors not in a designated body