### PR TITLE
chore: upgrade to Java 21 docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:21-jre-alpine
 COPY application/target/revalidation-uber.jar app.jar
 ENV JAVA_OPTS=${JVM_OPTS:-"-XX:+UseG1GC"}
 ENTRYPOINT ["java","-jar","app.jar"]


### PR DESCRIPTION
Eclipse Temurin is the distribution we build with. It is a natural choice, having not found an OpenJDK JRE.

The project has changed to using Java 17.
It would have been possible to use 17 but Java21 appears to work. This makes the build ready for changing the source version.

TIS21-5226: Disconnect Doctors