### PR TITLE
feat: use a buffered SQS client

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/config/AwsSqsQueueConfig.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/config/AwsSqsQueueConfig.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.revalidation.config;
 
 import com.amazonaws.services.sqs.AmazonSQSAsync;
 import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
+import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
 import org.springframework.context.annotation.Bean;
@@ -41,6 +42,6 @@ public class AwsSqsQueueConfig {
   @Primary
   @Bean
   public AmazonSQSAsync amazonSQSAsync() {
-    return AmazonSQSAsyncClientBuilder.defaultClient();
+    return new AmazonSQSBufferedAsyncClient(AmazonSQSAsyncClientBuilder.defaultClient());
   }
 }


### PR DESCRIPTION
This is a very simple way to introduce batching.
It will introduce some latency by design.
The default `QueueBufferConfig` uses a 200-millisecond delay.

TIS21-7167: Batch messages to SQS