### PR TITLE
chore: include details in logging from manual connection updates

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
@@ -164,8 +164,9 @@ public class DoctorsForDBService {
       doctorsForDb.setGmcLastUpdatedDateTime(message.getGmcLastUpdatedDateTime());
       doctorsRepository.save(doctorsForDb);
     } else {
-      log.info(
-          "No doctor found to update for doctor GMC Number: %s, DBC: %s, creating partial record");
+      log.info(String.format(
+          "No doctor found to update for doctor GMC Number: %s, DBC: %s, creating partial record",
+          message.getGmcId(), message.getDesignatedBodyCode()));
       DoctorsForDB partialDoctorRecord = DoctorsForDB.builder()
           .gmcReferenceNumber(message.getGmcId())
           .submissionDate(message.getSubmissionDate())


### PR DESCRIPTION
TIS21-7615: Revalidation Connections: New Connected Doctors do not update until the overnight sync runs