### PR TITLE
feat: upgrade AWS Java SDK to V2

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -151,10 +151,6 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>aws-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
             <artifactId>sqs</artifactId>
         </dependency>
     </dependencies>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -114,15 +114,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.awspring.cloud</groupId>
-            <artifactId>spring-cloud-starter-aws</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.awspring.cloud</groupId>
-            <artifactId>spring-cloud-starter-aws-messaging</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.github.cloudyrock.mongock</groupId>
             <artifactId>mongock-bom</artifactId>
             <version>4.3.8</version>
@@ -157,6 +148,14 @@
             <groupId>javax.persistence</groupId>
             <artifactId>javax.persistence-api</artifactId>
             <version>2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sqs</artifactId>
         </dependency>
     </dependencies>
 

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>revalidation</artifactId>
         <groupId>uk.nhs.hee.tis</groupId>
-        <version>1.0</version>
+        <version>1.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/config/AwsSqsQueueConfig.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/config/AwsSqsQueueConfig.java
@@ -21,27 +21,15 @@
 
 package uk.nhs.hee.tis.revalidation.config;
 
-import com.amazonaws.services.sqs.AmazonSQSAsync;
-import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
-import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
 @Configuration
 public class AwsSqsQueueConfig {
 
   @Bean
-  public QueueMessagingTemplate queueMessagingTemplate(AmazonSQSAsync amazonSqsAsync,
-      ObjectMapper objectMapper) {
-    return new QueueMessagingTemplate(amazonSqsAsync, null, objectMapper);
-  }
-
-  @Primary
-  @Bean
-  public AmazonSQSAsync amazonSQSAsync() {
-    return new AmazonSQSBufferedAsyncClient(AmazonSQSAsyncClientBuilder.defaultClient());
+  public SqsAsyncClient amazonSQSAsync() {
+    return SqsAsyncClient.builder().build();
   }
 }

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/config/AwsSqsQueueConfig.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/config/AwsSqsQueueConfig.java
@@ -30,6 +30,6 @@ public class AwsSqsQueueConfig {
 
   @Bean
   public SqsAsyncClient amazonSQSAsync() {
-    return SqsAsyncClient.builder().build();
+    return SqsAsyncClient.create();
   }
 }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>revalidation</artifactId>
         <groupId>uk.nhs.hee.tis</groupId>
-        <version>1.0</version>
+        <version>1.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
             ${project.build.directory}/checkstyle-result.xml
         </sonar.java.checkstyle.reportPaths>
         <commons-collections4.version>4.4</commons-collections4.version>
-        <spring-cloud-starter.version>2.4.2</spring-cloud-starter.version>
         <mockito-inline.version>4.0.0</mockito-inline.version>
     </properties>
 
@@ -176,19 +175,17 @@
             <!--spring cloud for sqs-->
 
             <dependency>
-                <groupId>io.awspring.cloud</groupId>
-                <artifactId>spring-cloud-starter-aws</artifactId>
-                <version>${spring-cloud-starter.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.awspring.cloud</groupId>
-                <artifactId>spring-cloud-starter-aws-messaging</artifactId>
-                <version>${spring-cloud-starter.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-data-elasticsearch</artifactId>
                 <version>${spring-boot.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.34.0</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <groupId>uk.nhs.hee.tis</groupId>
     <artifactId>revalidation</artifactId>
-    <version>1.0</version>
+    <version>1.0.1</version>
     <name>tis-revalidation-recommendation</name>
     <description>TIS Revalidation Recommendation project</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         </sonar.java.checkstyle.reportPaths>
         <commons-collections4.version>4.4</commons-collections4.version>
         <mockito-inline.version>4.0.0</mockito-inline.version>
+        <awssdk.version>2.33.0</awssdk.version>
     </properties>
 
     <dependencyManagement>
@@ -183,7 +184,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.33.0</version>
+                <version>${awssdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.34.0</version>
+                <version>2.33.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
1. AmazonSQSBufferedAsyncClient is removed from AWS SDK V2, so I updated the config to use SqsAsyncClient directly.
2. In the method `receiveMessage`, the syncEnd message will be sent after all batches are sent.

TIS21-7753