### PR TITLE
fix: send GMC batches async without blocking listener

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>revalidation</artifactId>
         <groupId>uk.nhs.hee.tis</groupId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>revalidation</artifactId>
         <groupId>uk.nhs.hee.tis</groupId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <groupId>uk.nhs.hee.tis</groupId>
     <artifactId>revalidation</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <name>tis-revalidation-recommendation</name>
     <description>TIS Revalidation Recommendation project</description>
 


### PR DESCRIPTION
During testing on Preprod, I found the sending of messages are blocked because of the statement "CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).... join()".
In my previous PR, message sending was actually blocking. It would wait to gather all the data before sending to SQS, which consumed a large amount of memory to store the messages. Therefore, I had to give up the mechanism of ensuring the `syncEnd` message is sent last, and switched to sending messages immediately and asynchronously.

TIS21-7753