### PR TITLE
refactor: use alias for Recommendations

### DIFF
--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/entity/RecommendationView.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/entity/RecommendationView.java
@@ -41,7 +41,7 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 @AllArgsConstructor
 @Builder
 @Data
-@Document(indexName = "recommendationindex")
+@Document(indexName = "recommendations")
 public class RecommendationView {
 
   @Id


### PR DESCRIPTION
TIS-5482: Use Alias to MasterDoctorIndex instead of separate RecommendationIndex