### PR TITLE
fix: date formatting error for external gmc connection change logs

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>revalidation</artifactId>
         <groupId>uk.nhs.hee.tis</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/dto/ConnectionLogDto.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/dto/ConnectionLogDto.java
@@ -20,6 +20,7 @@
  */
 package uk.nhs.hee.tis.revalidation.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.annotations.ApiModel;
 import java.time.LocalDateTime;
@@ -39,5 +40,6 @@ public class ConnectionLogDto {
   private String newDesignatedBodyCode;
   private String previousDesignatedBodyCode;
   private String updatedBy;
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "uuuu-MM-dd'T'HH:mm:ss.SSS")
   private LocalDateTime eventDateTime;
 }

--- a/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
+++ b/application/src/main/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBService.java
@@ -29,6 +29,7 @@ import static uk.nhs.hee.tis.revalidation.entity.UnderNotice.NO;
 import static uk.nhs.hee.tis.revalidation.entity.UnderNotice.YES;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -79,6 +80,7 @@ public class DoctorsForDBService {
   private final ConnectionLogPublisher connectionLogPublisher;
 
   private static final String UPDATED_BY_GMC = "Updated by GMC";
+  private static final String CONNECTION_LOG_DATETIME_FORMAT = "uuuu-MM-dd'T'HH:mm:ss.SSS";
 
   public DoctorsForDBService(DoctorsForDBRepository doctorsForDBRepository,
       RecommendationService recommendationService,
@@ -137,7 +139,8 @@ public class DoctorsForDBService {
     if (!newDesignatedBody.equals(previousDesignatedBody)) {
       ConnectionLogDto connectionLogDto = ConnectionLogDto.builder().gmcId(
               doctorsForDB.getGmcReferenceNumber())
-          .eventDateTime(gmcDoctor.getGmcLastUpdatedDateTime())
+          .eventDateTime(
+              formatLocalDateTimeForConnectionLogsOrNull(gmcDoctor.getGmcLastUpdatedDateTime()))
           .updatedBy(UPDATED_BY_GMC).previousDesignatedBodyCode(previousDesignatedBody)
           .newDesignatedBodyCode(newDesignatedBody).build();
       publishConnectionLog(connectionLogDto);
@@ -212,8 +215,11 @@ public class DoctorsForDBService {
               doctorsRepository.save(savedDoctor);
               publishConnectionLog(
                   ConnectionLogDto.builder().gmcId(savedDoctor.getGmcReferenceNumber())
-                      .previousDesignatedBodyCode(designatedBodyCode).newDesignatedBodyCode(null)
-                      .eventDateTime(requestDateTime).updatedBy(UPDATED_BY_GMC).build());
+                      .previousDesignatedBodyCode(designatedBodyCode)
+                      .newDesignatedBodyCode(null)
+                      .eventDateTime(formatLocalDateTimeForConnectionLogsOrNull(
+                          requestDateTime
+                      )).updatedBy(UPDATED_BY_GMC).build());
             } else {
               log.debug("Close one.  Doctor [{}] modified between updates and being disconnected.",
                   savedDoctor.getGmcReferenceNumber());
@@ -269,6 +275,14 @@ public class DoctorsForDBService {
 
   private void publishConnectionLog(ConnectionLogDto connectionLogDto) {
     connectionLogPublisher.publishToBroker(connectionLogDto);
+  }
+
+  private LocalDateTime formatLocalDateTimeForConnectionLogsOrNull(LocalDateTime logDateTime) {
+    if (logDateTime != null) {
+      return LocalDateTime.parse(
+          logDateTime.format(DateTimeFormatter.ofPattern(CONNECTION_LOG_DATETIME_FORMAT)));
+    }
+    return null;
   }
 
   //TODO: explore to implement cache

--- a/application/src/test/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBServiceTest.java
+++ b/application/src/test/java/uk/nhs/hee/tis/revalidation/service/DoctorsForDBServiceTest.java
@@ -125,6 +125,7 @@ class DoctorsForDBServiceTest {
   private String outcome1;
   private final LocalDateTime gmcLastUpdatedDateTime = LocalDateTime.now();
   private static final String UPDATED_BY_GMC = "Updated by GMC";
+  private static final String CONNECTION_LOG_DATETIME_FORMAT = "uuuu-MM-dd'T'HH:mm:ss.SSS";
 
   @BeforeEach
   void setup() {
@@ -655,7 +656,8 @@ class DoctorsForDBServiceTest {
   void shouldPublishConnectionLogIfNewConnectionGmcSync() {
     var dateFormat = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 
-    DoctorsForDbDto newDoctorDto = new DoctorsForDbDto(gmcRef1, fname1, lname1, subDate1.format(dateFormat),
+    DoctorsForDbDto newDoctorDto = new DoctorsForDbDto(gmcRef1, fname1, lname1,
+        subDate1.format(dateFormat),
         LocalDate.now().minusDays(5).format(dateFormat), un1.value(), "sanction", designatedBody1,
         LocalDateTime.now());
 
@@ -687,7 +689,8 @@ class DoctorsForDBServiceTest {
     DoctorsForDbCollectedEvent newConnectionEvent = new DoctorsForDbCollectedEvent(designatedBody1,
         cutoffDate, List.of());
 
-    when(repository.findByDesignatedBodyCodeAndGmcLastUpdatedDateTimeBefore(designatedBody1, cutoffDate)).thenReturn(List.of(staleDoctor));
+    when(repository.findByDesignatedBodyCodeAndGmcLastUpdatedDateTimeBefore(designatedBody1,
+        cutoffDate)).thenReturn(List.of(staleDoctor));
     when(repository.findById(gmcRef1)).thenReturn(Optional.of(staleDoctor));
 
     doctorsForDBService.handleDoctorsForDbCollectedEvent(newConnectionEvent);
@@ -700,7 +703,8 @@ class DoctorsForDBServiceTest {
     assertThat(result.getPreviousDesignatedBodyCode(), is(designatedBody1));
     assertNull(result.getNewDesignatedBodyCode());
     assertThat(result.getUpdatedBy(), is(UPDATED_BY_GMC));
-    assertThat(result.getEventDateTime(), is(cutoffDate));
+    assertThat(result.getEventDateTime(), is(LocalDateTime.parse(
+        cutoffDate.format(DateTimeFormatter.ofPattern(CONNECTION_LOG_DATETIME_FORMAT)))));
   }
 
   @Test
@@ -708,7 +712,8 @@ class DoctorsForDBServiceTest {
     var dateFormat = DateTimeFormatter.ofPattern("dd/MM/yyyy");
     LocalDateTime cutoffDate = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS);
 
-    DoctorsForDbDto newDoctorDto = new DoctorsForDbDto(gmcRef1, fname1, lname1, subDate1.format(dateFormat),
+    DoctorsForDbDto newDoctorDto = new DoctorsForDbDto(gmcRef1, fname1, lname1,
+        subDate1.format(dateFormat),
         LocalDate.now().minusDays(5).format(dateFormat), un1.value(), "sanction", designatedBody2,
         cutoffDate);
 
@@ -723,8 +728,10 @@ class DoctorsForDBServiceTest {
     DoctorsForDbCollectedEvent newConnectionEvent = new DoctorsForDbCollectedEvent(designatedBody2,
         cutoffDate, List.of(newDoctorDto));
 
-    when(repository.findByDesignatedBodyCodeAndGmcLastUpdatedDateTimeBefore(designatedBody2, cutoffDate)).thenReturn(List.of());
-    when(repository.findById(gmcRef1)).thenReturn(Optional.of(oldDoctor)).thenReturn(Optional.of(updatedDoctor));
+    when(repository.findByDesignatedBodyCodeAndGmcLastUpdatedDateTimeBefore(designatedBody2,
+        cutoffDate)).thenReturn(List.of());
+    when(repository.findById(gmcRef1)).thenReturn(Optional.of(oldDoctor))
+        .thenReturn(Optional.of(updatedDoctor));
 
     doctorsForDBService.handleDoctorsForDbCollectedEvent(newConnectionEvent);
 
@@ -736,7 +743,8 @@ class DoctorsForDBServiceTest {
     assertThat(result.getNewDesignatedBodyCode(), is(designatedBody2));
     assertThat(result.getPreviousDesignatedBodyCode(), is(designatedBody1));
     assertThat(result.getUpdatedBy(), is(UPDATED_BY_GMC));
-    assertThat(result.getEventDateTime(), is(cutoffDate));
+    assertThat(result.getEventDateTime(), is(LocalDateTime.parse(
+        cutoffDate.format(DateTimeFormatter.ofPattern(CONNECTION_LOG_DATETIME_FORMAT)))));
   }
 
   @Test
@@ -744,7 +752,8 @@ class DoctorsForDBServiceTest {
     var dateFormat = DateTimeFormatter.ofPattern("dd/MM/yyyy");
     LocalDateTime cutoffDate = LocalDateTime.now();
 
-    DoctorsForDbDto newDoctorDto = new DoctorsForDbDto(gmcRef1, fname1, lname1, subDate1.format(dateFormat),
+    DoctorsForDbDto newDoctorDto = new DoctorsForDbDto(gmcRef1, fname1, lname1,
+        subDate1.format(dateFormat),
         LocalDate.now().minusDays(5).format(dateFormat), un1.value(), "sanction", designatedBody2,
         cutoffDate);
 
@@ -759,8 +768,10 @@ class DoctorsForDBServiceTest {
     DoctorsForDbCollectedEvent newConnectionEvent = new DoctorsForDbCollectedEvent(designatedBody2,
         cutoffDate, List.of(newDoctorDto));
 
-    when(repository.findByDesignatedBodyCodeAndGmcLastUpdatedDateTimeBefore(designatedBody2, cutoffDate)).thenReturn(List.of(oldDoctor));
-    when(repository.findById(gmcRef1)).thenReturn(Optional.of(oldDoctor)).thenReturn(Optional.of(updatedDoctor));
+    when(repository.findByDesignatedBodyCodeAndGmcLastUpdatedDateTimeBefore(designatedBody2,
+        cutoffDate)).thenReturn(List.of(oldDoctor));
+    when(repository.findById(gmcRef1)).thenReturn(Optional.of(oldDoctor))
+        .thenReturn(Optional.of(updatedDoctor));
 
     doctorsForDBService.handleDoctorsForDbCollectedEvent(newConnectionEvent);
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>revalidation</artifactId>
         <groupId>uk.nhs.hee.tis</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <groupId>uk.nhs.hee.tis</groupId>
     <artifactId>revalidation</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <name>tis-revalidation-recommendation</name>
     <description>TIS Revalidation Recommendation project</description>
 


### PR DESCRIPTION
TIS21-8251: ConnectionLog Updates to Elasticsearch from GMC being dropped due to dateformat error